### PR TITLE
Add matplotlib visualizations to analytics artifacts

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -41,6 +41,7 @@ phases:
   samples.
 - `outliers.json` – detected outliers for numeric fields along with z-scores.
 - `report.txt` – natural-language summary for quick operator review.
+- `graphs/` – PNG visualizations such as histograms and scatter plots for quick exploration of numeric fields.
 
 Additional artifacts added by future phases (plots, models, etc.) should follow
 this pattern and be registered in the manifest under `artifacts/` with the

--- a/lambdas/processor/handler.py
+++ b/lambdas/processor/handler.py
@@ -105,6 +105,13 @@ def _persist_artifact(bucket: str, key: str, spec: Mapping[str, Any]) -> None:
         headers = spec.get("headers", [])
         rows = spec.get("rows", [])
         body = _csv_bytes(list(headers), list(rows))
+    elif kind == "image":
+        data = spec.get("data", b"")
+        if isinstance(data, memoryview):  # pragma: no cover - defensive conversion
+            data = data.tobytes()
+        if not isinstance(data, (bytes, bytearray)):
+            raise ValueError("Image artifact data must be bytes-like")
+        body = bytes(data)
     else:
         raise ValueError(f"Unsupported artifact kind: {kind}")
     _put_object(bucket, key, body, content_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ langgraph-checkpoint==2.1.1
 langgraph-prebuilt==0.6.4
 langgraph-sdk==0.2.9
 langsmith==0.4.32
+matplotlib==3.9.2
 mypy==1.18.2
 mypy_extensions==1.1.0
 openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- generate histogram and scatter plot PNG artifacts for numeric data and register them in the manifest
- allow the processor lambda to persist binary image artifacts and document the new graph outputs
- include matplotlib in the worker dependencies for visualization generation

## Testing
- python -m compileall services/workers/graph lambdas/processor

------
https://chatgpt.com/codex/tasks/task_e_68e54bacfde083228f45a95f254a1fb5