### PR TITLE
Add manifest browsing endpoints and hardened API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,33 @@ base64 encoded for compatibility. Common compression formats including GZIP,
 ZIP, TAR, and TAR.GZ archives are unpacked on the fly so that nested datasets
 are normalised without additional user effort. These capabilities ensure the
 platform accepts virtually any structured dataset for downstream analytics.
+
+## API hardening & observability
+
+The FastAPI service that fronts the ingestion workflow now exposes endpoints
+for rich status introspection and artifact browsing:
+
+* `GET /jobs/{jobId}` – returns job status, timestamps, result key metadata and
+  source information.
+* `GET /jobs/{jobId}/manifest` – fetches the manifest JSON captured during
+  ingestion for quick inspection.
+* `GET /jobs/{jobId}/artifacts` – lists any objects stored under the job's
+  artifact prefix with optional pagination and hierarchical filtering.
+* `GET /jobs/{jobId}/results/files` – enumerates published result files beneath
+  `artifacts/{jobId}/results/`.
+* `GET /jobs/{jobId}/results` – issues a signed download URL for either the
+  default `results.json` or any specific result file path.
+
+Each request is wrapped with structured logging and emits CloudWatch metrics
+for successful and failed job submissions, ensuring production visibility into
+latency, validation failures, and workflow launches.
+
+### Automated testing
+
+Python unit tests cover the job lifecycle, manifest/result discovery, and API
+validation logic. Run them locally with:
+
+```bash
+pip install -r services/api/requirements-dev.txt
+pytest services/api/tests
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "pytest services/api/tests",
     "build": "tsc -p .",
     "cdk:synth": "npm run build && cdk synth",
     "cdk:deploy": "npm run build && cdk deploy --all",

--- a/services/api/__init__.py
+++ b/services/api/__init__.py
@@ -1,0 +1,1 @@
+"""MetricFoundry API package."""

--- a/services/api/app.py
+++ b/services/api/app.py
@@ -1,9 +1,19 @@
 # services/api/app.py
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-import boto3, os, uuid, time, json
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+
+import boto3
 from botocore.exceptions import ClientError
+from fastapi import FastAPI, HTTPException, Query, Request
 from mangum import Mangum
+from pydantic import BaseModel
 
 # ---- Env ----
 BUCKET_NAME = os.environ["BUCKET_NAME"]          # artifacts bucket
@@ -11,11 +21,20 @@ TABLE_NAME  = os.environ["TABLE_NAME"]           # DynamoDB table
 QUEUE_URL   = os.environ.get("QUEUE_URL")        # optional
 STATE_MACHINE_ARN = os.environ["STATE_MACHINE_ARN"]
 
+# ---- Logging & Observability ----
+logger = logging.getLogger("metricfoundry.api")
+if not logger.handlers:
+    logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
+
+METRICS_NAMESPACE = os.environ.get("METRICS_NAMESPACE", "MetricFoundry/API")
+
 # ---- AWS ----
-s3  = boto3.client("s3")
+s3 = boto3.client("s3")
 ddb = boto3.resource("dynamodb")
 table = ddb.Table(TABLE_NAME)
 sfn = boto3.client("stepfunctions")
+cloudwatch = boto3.client("cloudwatch")
 
 app = FastAPI(title="MetricFoundry API")
 
@@ -25,8 +44,24 @@ class CreateJob(BaseModel):
     s3_path: str | None = None  # required if source_type == "s3"
 
 # ---- Helpers ----
+def record_metric(name: str, value: float = 1, unit: str = "Count", dimensions: Optional[Dict[str, str]] | None = None) -> None:
+    metric = {
+        "MetricName": name,
+        "Value": value,
+        "Unit": unit,
+    }
+    if dimensions:
+        metric["Dimensions"] = [{"Name": key, "Value": val} for key, val in dimensions.items()]
+
+    try:
+        cloudwatch.put_metric_data(Namespace=METRICS_NAMESPACE, MetricData=[metric])
+    except Exception as exc:  # pragma: no cover - observability must never block requests
+        logger.debug("failed to emit metric", extra={"metric": name, "error": str(exc)})
+
+
 def epoch() -> int:
     return int(time.time())
+
 
 def ddb_put_job(job_id: str, status: str, source: dict, created: int):
     item = {
@@ -45,14 +80,16 @@ def ddb_put_job(job_id: str, status: str, source: dict, created: int):
 
 
 def ddb_update_status(job_id: str, status: str, **attrs):
-    expr_names = {"#s": "status"}
+    expr_names = {"#s": "status", "#u": "updatedAt"}
     expr_vals = {":s": status, ":u": epoch()}
-    set_parts = ["#s = :s", "updatedAt = :u"]
+    set_parts = ["#s = :s", "#u = :u"]
 
     for key, value in attrs.items():
         placeholder = f":{key}"
         expr_vals[placeholder] = value
-        set_parts.append(f"{key} = {placeholder}")
+        expr_name = f"#{key}"
+        expr_names[expr_name] = key
+        set_parts.append(f"{expr_name} = {placeholder}")
 
     table.update_item(
         Key={"pk": f"job#{job_id}", "sk": "meta"},
@@ -60,6 +97,55 @@ def ddb_update_status(job_id: str, status: str, **attrs):
         ExpressionAttributeNames=expr_names,
         ExpressionAttributeValues=expr_vals,
     )
+
+
+def ensure_job(job_id: str) -> dict:
+    res = table.get_item(Key={"pk": f"job#{job_id}", "sk": "meta"})
+    item = res.get("Item")
+    if not item:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return item
+
+
+def serialize_objects(objects: Iterable[dict]) -> List[dict]:
+    serialized: List[dict] = []
+    for obj in objects:
+        modified = obj.get("LastModified")
+        if isinstance(modified, datetime):
+            if modified.tzinfo is None:
+                modified = modified.replace(tzinfo=timezone.utc)
+            modified_str = modified.astimezone(timezone.utc).isoformat()
+        else:
+            modified_str = None if modified is None else str(modified)
+        serialized.append(
+            {
+                "key": obj.get("Key"),
+                "size": obj.get("Size"),
+                "lastModified": modified_str,
+                "etag": obj.get("ETag"),
+                "storageClass": obj.get("StorageClass"),
+            }
+        )
+    return serialized
+
+
+def validate_prefix(job_id: str, prefix: Optional[str], *, base: str) -> str:
+    target = prefix or base
+    if not target.startswith(base):
+        raise HTTPException(status_code=400, detail="prefix must target this job's artifacts")
+    return target
+
+
+def ddb_item_to_job(job_id: str, item: dict) -> dict:
+    return {
+        "jobId": job_id,
+        "status": item.get("status"),
+        "createdAt": item.get("createdAt"),
+        "updatedAt": item.get("updatedAt"),
+        "resultKey": item.get("resultKey"),
+        "source": item.get("source"),
+    }
+
 
 # ---- Routes ----
 @app.get("/health")
@@ -69,13 +155,15 @@ def health():
 @app.post("/jobs")
 def create_job(body: CreateJob):
     if body.source_type not in ("upload", "s3"):
+        record_metric("JobValidationError", dimensions={"SourceType": str(body.source_type)})
         raise HTTPException(status_code=400, detail="source_type must be 'upload' or 's3'")
 
     job_id = str(uuid.uuid4())
     now = epoch()
+    dimensions = {"SourceType": body.source_type}
+    logger.info("creating job", extra={"job_id": job_id, **dimensions})
 
     if body.source_type == "upload":
-        # Unified with worker: artifacts/<jobId>/input/...
         key = f"artifacts/{job_id}/input/upload.csv"
         upload_url = s3.generate_presigned_url(
             ClientMethod="put_object",
@@ -85,11 +173,17 @@ def create_job(body: CreateJob):
         source = {"type": "upload", "bucket": BUCKET_NAME, "key": key}
     else:
         if not body.s3_path or not body.s3_path.startswith("s3://"):
+            record_metric("JobValidationError", dimensions=dimensions)
             raise HTTPException(status_code=400, detail="s3_path must be like s3://bucket/key")
         upload_url = None
         source = {"type": "s3", "uri": body.s3_path}
 
-    ddb_put_job(job_id, status="CREATED", source=source, created=now)
+    try:
+        ddb_put_job(job_id, status="CREATED", source=source, created=now)
+    except ClientError as e:
+        logger.exception("failed to persist job", extra={"job_id": job_id})
+        record_metric("JobPersistenceFailed", dimensions=dimensions)
+        raise HTTPException(status_code=502, detail="Unable to persist job") from e
 
     execution_input = json.dumps({"jobId": job_id})
     execution_name = f"job-{job_id}".replace("/", "-")
@@ -101,35 +195,134 @@ def create_job(body: CreateJob):
             input=execution_input,
         )
         ddb_update_status(job_id, "QUEUED")
+        record_metric("JobQueued", dimensions=dimensions)
     except ClientError as e:
         error = e.response.get("Error", {})
         message = error.get("Message") or str(e)
         ddb_update_status(job_id, "FAILED", error=message[:1000])
+        record_metric("JobWorkflowStartFailed", dimensions=dimensions)
+        logger.exception("failed to start workflow", extra={"job_id": job_id})
         raise HTTPException(status_code=502, detail="Failed to start job workflow") from e
     except Exception as e:
         ddb_update_status(job_id, "FAILED", error=str(e)[:1000])
+        record_metric("JobWorkflowStartFailed", dimensions=dimensions)
+        logger.exception("unexpected error starting workflow", extra={"job_id": job_id})
         raise HTTPException(status_code=502, detail="Failed to start job workflow") from e
 
+    record_metric("JobCreated", dimensions=dimensions)
+    logger.info("job queued", extra={"job_id": job_id, **dimensions})
     return {"jobId": job_id, "uploadUrl": upload_url}
 
 @app.get("/jobs/{job_id}")
 def get_job(job_id: str):
-    res = table.get_item(Key={"pk": f"job#{job_id}", "sk": "meta"})
-    item = res.get("Item")
-    if not item:
-        raise HTTPException(status_code=404, detail="Job not found")
+    item = ensure_job(job_id)
+    return ddb_item_to_job(job_id, item)
+
+
+@app.get("/jobs/{job_id}/manifest")
+def get_job_manifest(job_id: str):
+    ensure_job(job_id)
+    key = f"artifacts/{job_id}/manifest.json"
+    try:
+        obj = s3.get_object(Bucket=BUCKET_NAME, Key=key)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code")
+        if code in ("404", "NotFound", "NoSuchKey"):
+            raise HTTPException(status_code=404, detail="Manifest not available")
+        raise HTTPException(status_code=502, detail="Unable to load manifest")
+
+    try:
+        manifest = json.loads(obj["Body"].read().decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.exception("manifest is not valid JSON", extra={"job_id": job_id})
+        raise HTTPException(status_code=502, detail="Manifest is not valid JSON") from exc
+
     return {
         "jobId": job_id,
-        "status": item.get("status"),
-        "createdAt": item.get("createdAt"),
-        "updatedAt": item.get("updatedAt"),
-        "resultKey": item.get("resultKey"),
-        "source": item.get("source"),
+        "manifest": manifest,
+        "etag": obj.get("ETag"),
+        "contentLength": obj.get("ContentLength"),
     }
 
+
+@app.get("/jobs/{job_id}/artifacts")
+def list_job_artifacts(
+    job_id: str,
+    prefix: Optional[str] = Query(default=None, description="Prefix filter within the job's artifact directory"),
+    continuation_token: Optional[str] = Query(default=None, alias="continuationToken"),
+    page_size: int = Query(default=100, alias="pageSize", ge=1, le=1000),
+    delimiter: Optional[str] = Query(default="/", description="Delimiter used for common prefixes; empty to disable"),
+):
+    ensure_job(job_id)
+    base_prefix = f"artifacts/{job_id}/"
+    target_prefix = validate_prefix(job_id, prefix, base=base_prefix)
+
+    kwargs = {
+        "Bucket": BUCKET_NAME,
+        "Prefix": target_prefix,
+        "MaxKeys": page_size,
+    }
+    if continuation_token:
+        kwargs["ContinuationToken"] = continuation_token
+    if delimiter:
+        kwargs["Delimiter"] = delimiter
+
+    response = s3.list_objects_v2(**kwargs)
+    objects = serialize_objects(response.get("Contents", []))
+    common = [item.get("Prefix") for item in response.get("CommonPrefixes", [])]
+
+    return {
+        "jobId": job_id,
+        "prefix": target_prefix,
+        "objects": objects,
+        "commonPrefixes": common,
+        "isTruncated": response.get("IsTruncated", False),
+        "nextToken": response.get("NextContinuationToken"),
+    }
+
+
+@app.get("/jobs/{job_id}/results/files")
+def list_job_result_files(
+    job_id: str,
+    continuation_token: Optional[str] = Query(default=None, alias="continuationToken"),
+    page_size: int = Query(default=100, alias="pageSize", ge=1, le=1000),
+):
+    ensure_job(job_id)
+    prefix = f"artifacts/{job_id}/results/"
+    kwargs = {
+        "Bucket": BUCKET_NAME,
+        "Prefix": prefix,
+        "MaxKeys": page_size,
+        "Delimiter": "/",
+    }
+    if continuation_token:
+        kwargs["ContinuationToken"] = continuation_token
+
+    response = s3.list_objects_v2(**kwargs)
+    contents = response.get("Contents", [])
+    if not contents and not response.get("CommonPrefixes"):
+        raise HTTPException(status_code=404, detail="No result files available")
+
+    return {
+        "jobId": job_id,
+        "prefix": prefix,
+        "objects": serialize_objects(contents),
+        "commonPrefixes": [item.get("Prefix") for item in response.get("CommonPrefixes", [])],
+        "isTruncated": response.get("IsTruncated", False),
+        "nextToken": response.get("NextContinuationToken"),
+    }
+
+
 @app.get("/jobs/{job_id}/results")
-def get_job_results(job_id: str):
-    key = f"artifacts/{job_id}/results/results.json"
+def get_job_results(job_id: str, path: Optional[str] = Query(default=None, description="Relative path within the job's results directory")):
+    ensure_job(job_id)
+    prefix = f"artifacts/{job_id}/results/"
+    relative = path.lstrip("/") if path else "results.json"
+    key = prefix + relative
+
+    if not key.startswith(prefix):
+        raise HTTPException(status_code=400, detail="path must resolve within the results directory")
+
     try:
         s3.head_object(Bucket=BUCKET_NAME, Key=key)
     except ClientError as e:
@@ -137,12 +330,48 @@ def get_job_results(job_id: str):
         if code in ("404", "NotFound", "NoSuchKey"):
             raise HTTPException(status_code=404, detail="Results not available")
         raise HTTPException(status_code=502, detail="Unable to verify results availability")
+
     url = s3.generate_presigned_url(
         ClientMethod="get_object",
         Params={"Bucket": BUCKET_NAME, "Key": key},
         ExpiresIn=600,
     )
-    return {"jobId": job_id, "downloadUrl": url}
+    return {"jobId": job_id, "downloadUrl": url, "key": key}
+
+# ---- Middleware ----
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    start = time.time()
+    request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+    try:
+        response = await call_next(request)
+        duration_ms = int((time.time() - start) * 1000)
+        logger.info(
+            "request completed",
+            extra={
+                "path": request.url.path,
+                "method": request.method,
+                "status_code": response.status_code,
+                "duration_ms": duration_ms,
+                "request_id": request_id,
+            },
+        )
+        response.headers.setdefault("x-request-id", request_id)
+        return response
+    except Exception:
+        duration_ms = int((time.time() - start) * 1000)
+        logger.exception(
+            "request failed",
+            extra={
+                "path": request.url.path,
+                "method": request.method,
+                "duration_ms": duration_ms,
+                "request_id": request_id,
+            },
+        )
+        raise
+
 
 # ✅ GLOBAL Lambda handler (must be at module scope)
 handler = Mangum(app)
+

--- a/services/api/requirements-dev.txt
+++ b/services/api/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0.0

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -1,0 +1,189 @@
+import importlib
+import io
+import hashlib
+from datetime import datetime, timezone
+
+import pytest
+from botocore.exceptions import ClientError
+import anyio
+import httpx
+
+
+def _client_error(code: str, operation: str):
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+class InMemoryS3:
+    def __init__(self):
+        self._buckets: dict[str, dict[str, dict]] = {}
+
+    def _bucket(self, bucket: str) -> dict[str, dict]:
+        return self._buckets.setdefault(bucket, {})
+
+    def put_object(self, Bucket: str, Key: str, Body, ContentType: str | None = None):
+        if isinstance(Body, str):
+            body_bytes = Body.encode("utf-8")
+        elif hasattr(Body, "read"):
+            body_bytes = Body.read()
+        else:
+            body_bytes = Body
+        metadata = {
+            "Body": body_bytes,
+            "LastModified": datetime.now(timezone.utc),
+            "Size": len(body_bytes),
+            "ContentType": ContentType,
+            "ETag": hashlib.md5(body_bytes).hexdigest(),
+        }
+        self._bucket(Bucket)[Key] = metadata
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_object(self, Bucket: str, Key: str):
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise _client_error("NoSuchKey", "GetObject")
+        metadata = bucket[Key]
+        return {
+            "Body": io.BytesIO(metadata["Body"]),
+            "ContentLength": metadata["Size"],
+            "ETag": metadata["ETag"],
+            "LastModified": metadata["LastModified"],
+        }
+
+    def head_object(self, Bucket: str, Key: str):
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise _client_error("404", "HeadObject")
+        metadata = bucket[Key]
+        return {
+            "ContentLength": metadata["Size"],
+            "LastModified": metadata["LastModified"],
+        }
+
+    def list_objects_v2(self, Bucket: str, Prefix: str = "", MaxKeys: int = 1000, Delimiter: str | None = None, ContinuationToken: str | None = None):
+        bucket = self._bucket(Bucket)
+        keys = [key for key in bucket if key.startswith(Prefix)]
+        keys.sort()
+
+        contents = []
+        common_prefixes: set[str] = set()
+
+        for key in keys:
+            remainder = key[len(Prefix):]
+            if Delimiter and Delimiter in remainder:
+                prefix = Prefix + remainder.split(Delimiter, 1)[0] + Delimiter
+                common_prefixes.add(prefix)
+                continue
+            metadata = bucket[key]
+            contents.append({
+                "Key": key,
+                "Size": metadata["Size"],
+                "LastModified": metadata["LastModified"],
+                "ETag": metadata["ETag"],
+            })
+
+        return {
+            "Contents": contents[:MaxKeys],
+            "CommonPrefixes": [{"Prefix": value} for value in sorted(common_prefixes)],
+            "IsTruncated": False,
+        }
+
+    def generate_presigned_url(self, ClientMethod: str, Params: dict, ExpiresIn: int):
+        bucket = Params.get("Bucket")
+        key = Params.get("Key")
+        return f"https://presigned.local/{bucket}/{key}?expires={ExpiresIn}"
+
+
+class FakeDynamoTable:
+    def __init__(self):
+        self._items: dict[tuple[str, str], dict] = {}
+
+    def put_item(self, Item: dict, ConditionExpression: str | None = None):
+        key = (Item["pk"], Item["sk"])
+        if ConditionExpression and key in self._items:
+            raise _client_error("ConditionalCheckFailedException", "PutItem")
+        self._items[key] = dict(Item)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_item(self, Key: dict):
+        key = (Key["pk"], Key["sk"])
+        item = self._items.get(key)
+        return {"Item": dict(item)} if item else {}
+
+    def update_item(self, Key: dict, UpdateExpression: str, ExpressionAttributeNames: dict, ExpressionAttributeValues: dict):
+        key = (Key["pk"], Key["sk"])
+        if key not in self._items:
+            raise _client_error("ResourceNotFoundException", "UpdateItem")
+        item = self._items[key]
+        expression = UpdateExpression.replace("SET", "").strip()
+        for part in expression.split(","):
+            name_alias, value_alias = [segment.strip() for segment in part.split("=", 1)]
+            attribute_name = ExpressionAttributeNames.get(name_alias, name_alias)
+            value = ExpressionAttributeValues[value_alias]
+            item[attribute_name] = value
+        self._items[key] = item
+        return {"Attributes": dict(item)}
+
+
+class FakeStepFunctions:
+    def __init__(self):
+        self.executions = []
+
+    def start_execution(self, **kwargs):
+        self.executions.append(kwargs)
+        return {"executionArn": f"arn:aws:states:local:execution:{kwargs.get('name', 'execution')}"}
+
+
+class FakeCloudWatch:
+    def __init__(self):
+        self.metric_calls = []
+
+    def put_metric_data(self, Namespace, MetricData):
+        self.metric_calls.append({"Namespace": Namespace, "MetricData": MetricData})
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+
+@pytest.fixture()
+def api_app(monkeypatch):
+    monkeypatch.setenv("BUCKET_NAME", "metricfoundry-artifacts")
+    monkeypatch.setenv("TABLE_NAME", "metricfoundry-jobs")
+    monkeypatch.setenv("STATE_MACHINE_ARN", "arn:aws:states:local:stateMachine:metricfoundry")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    from services.api import app as app_module
+
+    importlib.reload(app_module)
+
+    fake_s3 = InMemoryS3()
+    fake_table = FakeDynamoTable()
+    fake_sfn = FakeStepFunctions()
+    fake_cw = FakeCloudWatch()
+
+    app_module.s3 = fake_s3
+    app_module.table = fake_table
+    app_module.sfn = fake_sfn
+    app_module.cloudwatch = fake_cw
+
+    transport = httpx.ASGITransport(app=app_module.app)
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+    class SyncClient:
+        def request(self, method: str, url: str, **kwargs):
+            return anyio.run(lambda: async_client.request(method, url, **kwargs))
+
+        def get(self, url: str, **kwargs):
+            return self.request("GET", url, **kwargs)
+
+        def post(self, url: str, **kwargs):
+            return self.request("POST", url, **kwargs)
+
+    client = SyncClient()
+
+    try:
+        yield {
+            "client": client,
+            "module": app_module,
+            "sfn": fake_sfn,
+            "cloudwatch": fake_cw,
+        }
+    finally:
+        anyio.run(async_client.aclose)

--- a/services/api/tests/test_app.py
+++ b/services/api/tests/test_app.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+
+
+def metric_names(metric_calls):
+    names = []
+    for call in metric_calls:
+        for metric in call.get("MetricData", []):
+            names.append(metric.get("MetricName"))
+    return names
+
+
+def test_create_upload_job_success(api_app):
+    client = api_app["client"]
+    response = client.post("/jobs", json={"source_type": "upload"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "jobId" in data
+    assert data["uploadUrl"].startswith("https://")
+
+    job_id = data["jobId"]
+    job_response = client.get(f"/jobs/{job_id}")
+    assert job_response.status_code == 200
+    job_payload = job_response.json()
+    assert job_payload["status"] == "QUEUED"
+
+    # Step Functions should have been triggered exactly once
+    assert len(api_app["sfn"].executions) == 1
+    assert api_app["sfn"].executions[0]["name"].startswith("job-")
+
+    # Metrics should reflect validation + success path
+    names = metric_names(api_app["cloudwatch"].metric_calls)
+    assert "JobCreated" in names
+    assert "JobQueued" in names
+
+
+def test_create_job_validation_error(api_app):
+    client = api_app["client"]
+    response = client.post("/jobs", json={"source_type": "invalid"})
+    assert response.status_code == 400
+    names = metric_names(api_app["cloudwatch"].metric_calls)
+    assert "JobValidationError" in names
+
+
+@pytest.mark.parametrize("path,expected_status", [(None, 200), ("data.csv", 200), ("missing.csv", 404)])
+def test_manifest_and_results_browsing(api_app, path, expected_status):
+    client = api_app["client"]
+    module = api_app["module"]
+
+    create_resp = client.post("/jobs", json={"source_type": "upload"})
+    assert create_resp.status_code == 200
+    job_id = create_resp.json()["jobId"]
+
+    manifest = {"inputs": ["upload.csv"], "results": ["results.json"]}
+    module.s3.put_object(
+        Bucket=module.BUCKET_NAME,
+        Key=f"artifacts/{job_id}/manifest.json",
+        Body=json.dumps(manifest),
+    )
+    module.s3.put_object(
+        Bucket=module.BUCKET_NAME,
+        Key=f"artifacts/{job_id}/results/results.json",
+        Body=json.dumps({"rowCount": 1}),
+    )
+    module.s3.put_object(
+        Bucket=module.BUCKET_NAME,
+        Key=f"artifacts/{job_id}/results/data.csv",
+        Body="value\n1\n",
+    )
+    module.s3.put_object(
+        Bucket=module.BUCKET_NAME,
+        Key=f"artifacts/{job_id}/results/subdir/details.json",
+        Body=json.dumps({"score": 10}),
+    )
+
+    manifest_resp = client.get(f"/jobs/{job_id}/manifest")
+    assert manifest_resp.status_code == 200
+    assert manifest_resp.json()["manifest"] == manifest
+
+    artifacts_resp = client.get(f"/jobs/{job_id}/artifacts")
+    assert artifacts_resp.status_code == 200
+    listed_keys = {obj["key"] for obj in artifacts_resp.json()["objects"]}
+    assert f"artifacts/{job_id}/manifest.json" in listed_keys
+    common_prefixes = set(artifacts_resp.json().get("commonPrefixes", []))
+    assert f"artifacts/{job_id}/results/" in common_prefixes
+
+    filtered_resp = client.get(
+        f"/jobs/{job_id}/artifacts",
+        params={"prefix": f"artifacts/{job_id}/results/"},
+    )
+    assert filtered_resp.status_code == 200
+    filtered_keys = {obj["key"] for obj in filtered_resp.json()["objects"]}
+    assert all(key.startswith(f"artifacts/{job_id}/results/") for key in filtered_keys)
+
+    files_resp = client.get(f"/jobs/{job_id}/results/files")
+    assert files_resp.status_code == 200
+    file_keys = {obj["key"] for obj in files_resp.json()["objects"]}
+    assert f"artifacts/{job_id}/results/data.csv" in file_keys
+    assert f"artifacts/{job_id}/results/subdir/details.json" not in file_keys
+    assert f"artifacts/{job_id}/results/subdir/" in files_resp.json()["commonPrefixes"]
+
+    params = {"path": path} if path else {}
+    download_resp = client.get(f"/jobs/{job_id}/results", params=params)
+    assert download_resp.status_code == expected_status
+    if expected_status == 200:
+        payload = download_resp.json()
+        assert payload["key"].endswith(path or "results.json")
+        assert payload["downloadUrl"].startswith("https://")
+
+
+def test_results_listing_without_files(api_app):
+    client = api_app["client"]
+    create_resp = client.post("/jobs", json={"source_type": "upload"})
+    job_id = create_resp.json()["jobId"]
+
+    files_resp = client.get(f"/jobs/{job_id}/results/files")
+    assert files_resp.status_code == 404
+
+    manifest_resp = client.get(f"/jobs/{job_id}/manifest")
+    assert manifest_resp.status_code == 404
+
+
+def test_artifact_prefix_outside_job_is_rejected(api_app):
+    client = api_app["client"]
+    create_resp = client.post("/jobs", json={"source_type": "upload"})
+    job_id = create_resp.json()["jobId"]
+
+    resp = client.get(f"/jobs/{job_id}/artifacts", params={"prefix": "other/"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add structured logging, CloudWatch metrics, and new API endpoints for listing job artifacts and results
- provide in-memory AWS stubs plus pytest coverage for job creation, manifest browsing, and error handling
- wire pytest into the default test command and document the expanded surface area in the README

## Testing
- pytest services/api/tests

------
https://chatgpt.com/codex/tasks/task_e_68e5502b223083229b2bab2928c2f7ea