### PR TITLE
Package processor Lambda dependencies with container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+node_modules
+cdk.out
+__pycache__
+*.pyc
+.env
+*.tmp

--- a/infra/stacks/core.ts
+++ b/infra/stacks/core.ts
@@ -97,10 +97,10 @@ export class MetricFoundryCoreStack extends Stack {
     // =====================================================================
     // Processor Lambda: invoked by Step Functions after staging completes
     // =====================================================================
-    const processorFn = new lambda.Function(this, "ProcessorFn", {
-      runtime: lambda.Runtime.PYTHON_3_12,
-      handler: "handler.main",
-      code: lambda.Code.fromAsset("lambdas/processor"),
+    const processorFn = new lambda.DockerImageFunction(this, "ProcessorFn", {
+      code: lambda.DockerImageCode.fromImageAsset(".", {
+        file: "lambdas/processor/Dockerfile",
+      }),
       timeout: Duration.minutes(2),
       memorySize: 1024,
       environment: {

--- a/lambdas/processor/Dockerfile
+++ b/lambdas/processor/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+# Install heavyweight analytics dependencies required by the processor.
+COPY lambdas/processor/requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && rm -rf ~/.cache/pip
+
+# Copy the shared services code and the processor handler into the image.
+COPY services ${LAMBDA_TASK_ROOT}/services
+COPY lambdas/processor ${LAMBDA_TASK_ROOT}/
+
+CMD ["handler.main"]

--- a/lambdas/processor/requirements.txt
+++ b/lambdas/processor/requirements.txt
@@ -1,0 +1,6 @@
+pandas==2.2.3
+pyarrow==17.0.0
+scikit-learn==1.5.2
+matplotlib==3.9.2
+joblib==1.4.2
+langgraph==0.6.8


### PR DESCRIPTION
## Summary
- add a Dockerfile and dependency manifest so the processor Lambda runs from a container image with heavy analytics libraries installed
- switch the CDK stack to deploy the processor from the container image and add a repository-wide .dockerignore for leaner builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e555ff8bb483228de986af13c72f45