### PR TITLE
Add integration tests for staging and analytics pipelines

### DIFF
--- a/tests/integration/test_graph_pipeline.py
+++ b/tests/integration/test_graph_pipeline.py
@@ -1,0 +1,173 @@
+import csv
+import gzip
+import importlib
+import io
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from types import ModuleType
+from typing import Iterable, List
+
+import pytest
+
+
+SAMPLE_ROWS = [{"id": index, "value": index * 10} for index in range(1, 11)]
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+
+def _ensure_state_graph_stub() -> None:
+    try:
+        importlib.import_module("langgraph.graph")
+        return
+    except Exception:
+        pass
+
+    pkg = ModuleType("langgraph")
+    mod = ModuleType("langgraph.graph")
+
+    END = object()
+
+    class _CompiledGraph:
+        def __init__(self, nodes, order):
+            self._nodes = nodes
+            self._order = order
+
+        def invoke(self, initial_state):
+            state = dict(initial_state)
+            for name in self._order:
+                update = self._nodes[name](state)
+                if update:
+                    state.update(update)
+            return state
+
+    class StateGraph:
+        def __init__(self, _state_type):
+            self._nodes = {}
+            self._edges = {}
+            self._entry = None
+
+        def add_node(self, name, func):
+            self._nodes[name] = func
+
+        def set_entry_point(self, name):
+            self._entry = name
+
+        def add_edge(self, source, dest):
+            self._edges.setdefault(source, []).append(dest)
+
+        def compile(self):
+            order: List[str] = []
+            current = self._entry
+            visited: set[str] = set()
+            while current is not None and current != END:
+                if current in visited:
+                    raise RuntimeError("cycle detected in stub graph")
+                visited.add(current)
+                order.append(current)
+                next_nodes = self._edges.get(current, [])
+                current = next_nodes[0] if next_nodes else None
+            return _CompiledGraph(self._nodes, order)
+
+    mod.END = END
+    mod.StateGraph = StateGraph
+    pkg.graph = mod
+    sys.modules["langgraph"] = pkg
+    sys.modules["langgraph.graph"] = mod
+
+
+def _csv_bytes(rows: Iterable[dict]) -> bytes:
+    buffer = io.StringIO()
+    fieldnames = list(rows[0].keys()) if isinstance(rows, list) else None
+    if fieldnames is None:
+        first = next(iter(rows))
+        fieldnames = list(first.keys())
+        rows = [first] + list(rows)
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue().encode("utf-8")
+
+
+def _jsonl_bytes(rows: Iterable[dict]) -> bytes:
+    return "\n".join(json.dumps(row) for row in rows).encode("utf-8") + b"\n"
+
+
+def _gzip_bytes(payload: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as handle:
+        handle.write(payload)
+    return buffer.getvalue()
+
+
+def _sqlite_bytes(rows: Iterable[dict]) -> bytes:
+    temp = tempfile.NamedTemporaryFile(delete=False, suffix=".sqlite")
+    try:
+        with sqlite3.connect(temp.name) as conn:
+            conn.execute("CREATE TABLE metrics (id INTEGER, value INTEGER)")
+            conn.executemany(
+                "INSERT INTO metrics (id, value) VALUES (?, ?)",
+                [(row["id"], row["value"]) for row in rows],
+            )
+            conn.commit()
+        with open(temp.name, "rb") as handle:
+            return handle.read()
+    finally:
+        try:
+            os.unlink(temp.name)
+        except FileNotFoundError:
+            pass
+
+
+_ensure_state_graph_stub()
+module = importlib.import_module("services.workers.graph.graph")
+importlib.reload(module)
+run_pipeline = module.run_pipeline
+PHASE_ORDER = module.PHASE_ORDER
+
+
+@pytest.mark.parametrize(
+    "key, body, expected_format",
+    [
+        ("sample.csv", _csv_bytes(SAMPLE_ROWS), "csv"),
+        ("sample.jsonl", _jsonl_bytes(SAMPLE_ROWS), "jsonl"),
+        ("compressed.csv.gz", _gzip_bytes(_csv_bytes(SAMPLE_ROWS)), "csv"),
+        ("dataset.sqlite", _sqlite_bytes(SAMPLE_ROWS), "sqlite"),
+    ],
+)
+def test_pipeline_ingests_diverse_formats(key, body, expected_format):
+    job_id = f"job-{expected_format}"
+    result = run_pipeline(job_id, {"key": key}, body, artifact_prefix=f"artifacts/{job_id}")
+
+    for phase in PHASE_ORDER:
+        assert phase in result.phases
+
+    ingest = result.phases["ingest"]
+    assert ingest["rows"] == len(SAMPLE_ROWS)
+    assert ingest["sourceFormat"] == expected_format
+    assert set(ingest["columns"]) == {"id", "value"}
+
+    metrics = result.metrics
+    assert metrics["rows"] == len(SAMPLE_ROWS)
+    assert metrics["columns"] == 2
+    assert 0.0 <= metrics["datasetCompleteness"] <= 1.0
+
+    manifest_keys = {entry["key"] for entry in result.manifest["artifacts"]}
+    assert f"artifacts/{job_id}/results/results.json" in manifest_keys
+    assert f"artifacts/{job_id}/results/manifest.json" in manifest_keys
+
+    contents_keys = result.artifact_contents.keys()
+    assert "results/descriptive_stats.csv" in contents_keys
+    assert "results/report.txt" in contents_keys
+
+    ml_phase = result.phases["ml_inference"]
+    assert isinstance(ml_phase, dict)
+    assert ml_phase.get("status") in {"failed", "skipped", "completed"}
+
+    summary = result.phases["nl_report"]["summary"]
+    assert f"{len(SAMPLE_ROWS)} rows" in summary

--- a/tests/integration/test_stage_lambda.py
+++ b/tests/integration/test_stage_lambda.py
@@ -1,0 +1,188 @@
+import importlib
+import io
+import hashlib
+from datetime import datetime, timezone
+from typing import Dict
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+def _client_error(code: str, operation: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+class FakeS3:
+    def __init__(self) -> None:
+        self._buckets: Dict[str, Dict[str, Dict[str, object]]] = {}
+
+    def _bucket(self, name: str) -> Dict[str, Dict[str, object]]:
+        return self._buckets.setdefault(name, {})
+
+    def put_object(self, Bucket: str, Key: str, Body, ContentType: str | None = None):
+        if isinstance(Body, str):
+            payload = Body.encode("utf-8")
+        elif hasattr(Body, "read"):
+            payload = Body.read()
+        else:
+            payload = bytes(Body)
+        metadata = {
+            "Body": payload,
+            "ContentLength": len(payload),
+            "ContentType": ContentType,
+            "LastModified": datetime.now(timezone.utc),
+            "ETag": hashlib.md5(payload).hexdigest(),
+        }
+        self._bucket(Bucket)[Key] = metadata
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def copy_object(self, Bucket: str, Key: str, CopySource: Dict[str, str]):
+        source_bucket = CopySource["Bucket"]
+        source_key = CopySource["Key"]
+        source = self._bucket(source_bucket).get(source_key)
+        if source is None:
+            raise _client_error("NoSuchKey", "CopyObject")
+        copied = dict(source)
+        self._bucket(Bucket)[Key] = copied
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def head_object(self, Bucket: str, Key: str):
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise _client_error("404", "HeadObject")
+        metadata = bucket[Key]
+        return {
+            "ContentLength": metadata["ContentLength"],
+            "ContentType": metadata.get("ContentType"),
+            "LastModified": metadata["LastModified"],
+        }
+
+    def get_object(self, Bucket: str, Key: str):
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise _client_error("NoSuchKey", "GetObject")
+        metadata = bucket[Key]
+        return {
+            "Body": io.BytesIO(metadata["Body"]),
+            "ContentLength": metadata["ContentLength"],
+            "ContentType": metadata.get("ContentType"),
+            "LastModified": metadata["LastModified"],
+        }
+
+
+class FakeDynamoTable:
+    def __init__(self) -> None:
+        self._items: Dict[tuple[str, str], Dict[str, object]] = {}
+
+    def put_item(self, Item: Dict[str, object]):
+        key = (Item["pk"], Item["sk"])
+        self._items[key] = dict(Item)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_item(self, Key: Dict[str, str]):
+        key = (Key["pk"], Key["sk"])
+        item = self._items.get(key)
+        return {"Item": dict(item)} if item else {}
+
+    def update_item(self, Key: Dict[str, str], UpdateExpression: str, ExpressionAttributeNames: Dict[str, str], ExpressionAttributeValues: Dict[str, object]):
+        key = (Key["pk"], Key["sk"])
+        if key not in self._items:
+            raise _client_error("ResourceNotFoundException", "UpdateItem")
+        item = dict(self._items[key])
+        expression = UpdateExpression.replace("SET", "").strip()
+        for part in expression.split(","):
+            name_alias, value_alias = [segment.strip() for segment in part.split("=", 1)]
+            attribute_name = ExpressionAttributeNames.get(name_alias, name_alias)
+            item[attribute_name] = ExpressionAttributeValues[value_alias]
+        self._items[key] = item
+        return {"Attributes": dict(item)}
+
+
+class FakeDynamoResource:
+    def __init__(self, table: FakeDynamoTable) -> None:
+        self._table = table
+
+    def Table(self, _name: str) -> FakeDynamoTable:  # noqa: N802 - mimic boto3
+        return self._table
+
+
+@pytest.fixture()
+def stage_lambda(monkeypatch):
+    monkeypatch.setenv("JOBS_TABLE", "jobs-table")
+    monkeypatch.setenv("ARTIFACTS_BUCKET", "artifacts-bucket")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    module = importlib.import_module("lambdas.stage.handler")
+    importlib.reload(module)
+
+    fake_s3 = FakeS3()
+    fake_table = FakeDynamoTable()
+
+    module.s3 = fake_s3
+    module.ddb = FakeDynamoResource(fake_table)
+
+    return module, fake_s3, fake_table
+
+
+@pytest.mark.parametrize(
+    "job_source, bucket, key, body, content_type, expected_format",
+    [
+        (
+            {"type": "upload", "bucket": "incoming", "key": "uploads/sample.csv"},
+            "incoming",
+            "uploads/sample.csv",
+            b"id,value\n1,2\n",
+            "text/csv",
+            "csv",
+        ),
+        (
+            {"type": "s3", "uri": "s3://external/data.jsonl"},
+            "external",
+            "data.jsonl",
+            b"{\"id\": 1}\n",
+            "application/json",
+            "jsonl",
+        ),
+        (
+            {"type": "upload", "bucket": "incoming", "key": "uploads/metrics.parquet"},
+            "incoming",
+            "uploads/metrics.parquet",
+            b"PARQUET",
+            "application/octet-stream",
+            "parquet",
+        ),
+    ],
+)
+def test_stage_lambda_end_to_end(stage_lambda, job_source, bucket, key, body, content_type, expected_format):
+    module, fake_s3, fake_table = stage_lambda
+    job_id = f"job-{expected_format}"
+
+    fake_table.put_item(
+        {
+            "pk": f"job#{job_id}",
+            "sk": "meta",
+            "status": "QUEUED",
+            "source": job_source,
+        }
+    )
+
+    fake_s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType=content_type)
+
+    result = module.handler({"jobId": job_id}, None)
+
+    filename = key.rsplit("/", 1)[-1]
+    expected_key = f"artifacts/{job_id}/input/{filename}"
+
+    staged = fake_s3.get_object(Bucket=module.ARTIFACTS_BUCKET, Key=expected_key)
+    assert staged["Body"].read() == body
+
+    record = fake_table.get_item({"pk": f"job#{job_id}", "sk": "meta"}).get("Item")
+    assert record is not None
+    assert record["status"] == module.STATUS_STAGED
+    assert record["inputKey"] == expected_key
+    assert record["inputMetadata"]["format"] == expected_format
+    assert record["inputMetadata"]["sourceType"] == job_source["type"]
+
+    metadata = result["metadata"]
+    assert metadata["format"] == expected_format
+    assert result["input"]["key"] == expected_key


### PR DESCRIPTION
## Summary
- add an integration suite for the staging Lambda covering upload and S3 based sources
- stub LangGraph when unavailable and add pipeline integration tests across CSV, JSONL, gzip, and SQLite inputs

## Testing
- pytest tests/integration -q
- pytest services/api/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e55d6793a88322bfab23e650060785