### PR TITLE
Remove unused jobs queue from CDK stacks

### DIFF
--- a/infra/main.ts
+++ b/infra/main.ts
@@ -10,6 +10,5 @@ const core = new MetricFoundryCoreStack(app, "MetricFoundry-Core");
 new MetricFoundryApiStack(app, "MetricFoundry-Api", {
   artifactsBucket: core.artifacts,
   jobsTable: core.jobsTable,
-  jobsQueue: core.jobsQueue,
   workflow: core.jobsStateMachine,
 });

--- a/infra/stacks/core.ts
+++ b/infra/stacks/core.ts
@@ -2,7 +2,6 @@
 import { Stack, StackProps, Duration, RemovalPolicy } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as ddb from "aws-cdk-lib/aws-dynamodb";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as iam from "aws-cdk-lib/aws-iam";
@@ -11,7 +10,6 @@ import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
 
 export class MetricFoundryCoreStack extends Stack {
   public readonly artifacts: s3.Bucket;
-  public readonly jobsQueue: sqs.Queue;
   public readonly jobsTable: ddb.Table;
   public readonly jobsStateMachine: sfn.StateMachine;
 
@@ -36,13 +34,6 @@ export class MetricFoundryCoreStack extends Stack {
       ],
       removalPolicy: RemovalPolicy.RETAIN,
       autoDeleteObjects: false,
-    });
-
-    // --- SQS (existing, unused by the worker but kept as-is) ---
-    const dlq = new sqs.Queue(this, "DLQ");
-    this.jobsQueue = new sqs.Queue(this, "JobsQueue", {
-      visibilityTimeout: Duration.seconds(90),
-      deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
     });
 
     // --- Jobs table (pk/sk schema retained) ---

--- a/services/api/app.py
+++ b/services/api/app.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel
 # ---- Env ----
 BUCKET_NAME = os.environ["BUCKET_NAME"]          # artifacts bucket
 TABLE_NAME  = os.environ["TABLE_NAME"]           # DynamoDB table
-QUEUE_URL   = os.environ.get("QUEUE_URL")        # optional
 STATE_MACHINE_ARN = os.environ["STATE_MACHINE_ARN"]
 
 # ---- Logging & Observability ----


### PR DESCRIPTION
## Summary
- remove the unused jobs SQS queue from the core CDK stack and its outputs
- simplify the API stack by dropping the unused queue parameter and environment variable
- clarify the FastAPI service configuration now that no queue is provisioned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e561e05ab08322a0923e55f184ec0e