### PR TITLE
Add curated artifact bundles to manifest outputs

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -12,14 +12,18 @@ artifacts/<jobId>/
 │   ├── dq_validate.json
 │   ├── descriptive_stats.json
 │   ├── nl_report.json
-│   └── finalize.json
+│   ├── finalize.json
+│   └── phase_payloads.zip
 └── results/
     ├── correlations.csv
     ├── descriptive_stats.csv
     ├── manifest.json
     ├── outliers.json
     ├── report.txt
-    └── results.json
+    ├── results.json
+    └── bundles/
+        ├── analytics_bundle.zip
+        └── visualizations.zip
 ```
 
 ## Phase artifacts
@@ -42,7 +46,18 @@ phases:
 - `outliers.json` – detected outliers for numeric fields along with z-scores.
 - `report.txt` – natural-language summary for quick operator review.
 - `graphs/` – PNG visualizations such as histograms and scatter plots for quick exploration of numeric fields.
+- `bundles/analytics_bundle.zip` – curated download that groups descriptive
+  statistics, correlation matrices, predictions, and other tabular outputs.
+- `bundles/visualizations.zip` – single archive containing all generated
+  histograms and scatter plots.
 
 Additional artifacts added by future phases (plots, models, etc.) should follow
 this pattern and be registered in the manifest under `artifacts/` with the
 relative key `artifacts/<jobId>/<path>`.
+
+## Phase archives
+
+To simplify debugging, `phases/phase_payloads.zip` consolidates the individual
+`<phase>.json` documents emitted by the LangGraph pipeline into a single
+downloadable archive. This removes the need to fetch each phase output one at a
+time when inspecting job execution details.

--- a/tests/integration/test_graph_pipeline.py
+++ b/tests/integration/test_graph_pipeline.py
@@ -189,10 +189,14 @@ def test_pipeline_ingests_diverse_formats(key, body, expected_format):
     manifest_keys = {entry["key"] for entry in result.manifest["artifacts"]}
     assert f"artifacts/{job_id}/results/results.json" in manifest_keys
     assert f"artifacts/{job_id}/results/manifest.json" in manifest_keys
+    assert f"artifacts/{job_id}/results/bundles/analytics_bundle.zip" in manifest_keys
+    assert f"artifacts/{job_id}/phases/phase_payloads.zip" in manifest_keys
 
     contents_keys = result.artifact_contents.keys()
     assert "results/descriptive_stats.csv" in contents_keys
     assert "results/report.txt" in contents_keys
+    assert "results/bundles/analytics_bundle.zip" in contents_keys
+    assert "phases/phase_payloads.zip" in contents_keys
 
     ml_phase = result.phases["ml_inference"]
     assert isinstance(ml_phase, dict)


### PR DESCRIPTION
## Summary
- build curated zip bundles for analytics outputs and phase payloads so the manifest offers convenient downloads
- document the new bundle layout in the artifact reference and update integration coverage for the manifest contents

## Testing
- pytest tests/integration/test_graph_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e585cda8788322a571889f81b25c1e