### PR TITLE
Bundle dependencies for stage Lambda

### DIFF
--- a/infra/stacks/core.ts
+++ b/infra/stacks/core.ts
@@ -51,7 +51,19 @@ export class MetricFoundryCoreStack extends Stack {
     const stageFn = new lambda.Function(this, "StageSourceFn", {
       runtime: lambda.Runtime.PYTHON_3_12,
       handler: "handler.handler",
-      code: lambda.Code.fromAsset("lambdas/stage"),
+      code: lambda.Code.fromAsset("lambdas/stage", {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_12.bundlingImage,
+          command: [
+            "bash",
+            "-c",
+            [
+              "pip install -r requirements.txt -t /asset-output",
+              "cp -au . /asset-output",
+            ].join(" && "),
+          ],
+        },
+      }),
       timeout: Duration.minutes(2),
       memorySize: 512,
       environment: {

--- a/lambdas/stage/requirements.txt
+++ b/lambdas/stage/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.32.5
+SQLAlchemy==2.0.43


### PR DESCRIPTION
## Summary
- bundle the staging Lambda with a Docker-based build step that installs its Python dependencies
- add a minimal requirements file so requests and SQLAlchemy are included in the deployment package

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e588e1a15083228bc5772ac5e9bc16