### PR TITLE
Fix dataset file input reset assignment

### DIFF
--- a/dashboard/components/UploadForm.tsx
+++ b/dashboard/components/UploadForm.tsx
@@ -18,7 +18,10 @@ export function UploadForm({ onJobCreated, onUploadFinished, onError }: UploadFo
     setFile(null);
     setS3Path('');
     if (typeof window !== 'undefined') {
-      (document.getElementById('dataset-file-input') as HTMLInputElement | null)?.value = '';
+      const input = document.getElementById('dataset-file-input');
+      if (input instanceof HTMLInputElement) {
+        input.value = '';
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- guard the dataset file input reset with an instanceof check to avoid invalid optional chaining assignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e598ba87948322b51b8e37ceb74a22