### PR TITLE
Support secret-managed SQL connections in staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ field, enabling teams to declaratively pull data from almost any system:
   headers, and request bodies before staging them in S3.
 * **Databases:** execute SQL queries against JDBC/SQLAlchemy compatible
   databases (including SQLite for local extracts) and persist the result set as
-  CSV or JSONL.
+  CSV or JSONL. Connection strings can be provided inline _or_ referenced via
+  AWS Secrets Manager / Systems Manager Parameter Store identifiers so
+  credentials never transit the API payload.
 * **Warehouses:** target Snowflake, Redshift, BigQuery, or Databricks using the
   same SQL workflow, producing staged artifacts tagged with warehouse metadata
-  for downstream observability.
+  for downstream observability. Warehouse connectors share the same secret and
+  parameter indirection used by databases, letting teams centralise credential
+  management.
 
 This connector catalogue underpins the platform's "any dataset" promise while
 keeping the job orchestration API consistent for every source type.


### PR DESCRIPTION
## Summary
- allow database and warehouse jobs to reference credentials stored in Secrets Manager or Parameter Store
- update the staging Lambda to resolve SQL connection strings from those secret references at runtime
- extend the test suites and documentation to cover the new credential indirection flow

## Testing
- pytest services/api/tests/test_app.py tests/integration/test_stage_lambda.py

------
https://chatgpt.com/codex/tasks/task_e_68e5a01b35c08322b5287f9fdfde5d75