### PR TITLE
Fix traversal vulnerabilities in artifact and results handlers

### DIFF
--- a/services/api/tests/test_app.py
+++ b/services/api/tests/test_app.py
@@ -246,3 +246,21 @@ def test_artifact_prefix_outside_job_is_rejected(api_app):
 
     resp = client.get(f"/jobs/{job_id}/artifacts", params={"prefix": "other/"})
     assert resp.status_code == 400
+
+    resp = client.get(
+        f"/jobs/{job_id}/artifacts",
+        params={"prefix": f"artifacts/{job_id}/../other"},
+    )
+    assert resp.status_code == 400
+
+
+def test_results_path_outside_job_is_rejected(api_app):
+    client = api_app["client"]
+    create_resp = client.post("/jobs", json={"source_type": "upload"})
+    job_id = create_resp.json()["jobId"]
+
+    resp = client.get(
+        f"/jobs/{job_id}/results",
+        params={"path": "../manifest.json"},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- canonicalize S3 prefixes before listing artifacts to block traversal attempts
- harden the results download endpoint to reject paths escaping the job directory
- add regression tests covering malicious prefixes and result paths

## Testing
- pytest services/api/tests/test_app.py
- pytest tests/integration/test_api_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68e69542f66c83228c5f2d15a14ac409