### PR TITLE
Support secure SQL connection metadata in staging pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ field, enabling teams to declaratively pull data from almost any system:
   headers, and request bodies before staging them in S3.
 * **Databases:** execute SQL queries against JDBC/SQLAlchemy compatible
   databases (including SQLite for local extracts) and persist the result set as
-  CSV or JSONL. Connection strings can be provided inline _or_ referenced via
-  AWS Secrets Manager / Systems Manager Parameter Store identifiers so
-  credentials never transit the API payload.
+  CSV or JSONL. The API now persists connection metadata under a dedicated
+  `connection` object on each job. Inline URLs use `{ "type": "inline", "url": "..." }`
+  while secure deployments reference AWS Secrets Manager or Systems Manager
+  Parameter Store, for example `{ "type": "secretsManager", "secretArn": "...",
+  "secretField": "url" }`. The staging Lambda resolves these indirections at
+  runtime so credentials never transit the API payload.
 * **Warehouses:** target Snowflake, Redshift, BigQuery, or Databricks using the
   same SQL workflow, producing staged artifacts tagged with warehouse metadata
-  for downstream observability. Warehouse connectors share the same secret and
-  parameter indirection used by databases, letting teams centralise credential
-  management.
+  for downstream observability. Warehouse connectors share the same connection
+  schema, letting teams centralise credential management across both OLTP and
+  analytical systems.
 
 This connector catalogue underpins the platform's "any dataset" promise while
 keeping the job orchestration API consistent for every source type.

--- a/tests/integration/test_stage_lambda.py
+++ b/tests/integration/test_stage_lambda.py
@@ -351,8 +351,11 @@ def test_stage_lambda_database_secret(stage_lambda, tmp_path):
             "status": "QUEUED",
             "source": {
                 "type": "database",
-                "secretArn": secret_arn,
-                "secretField": "url",
+                "connection": {
+                    "type": "secretsManager",
+                    "secretArn": secret_arn,
+                    "secretField": "url",
+                },
                 "query": "SELECT value FROM secrets",
                 "filename": "secret.csv",
             },
@@ -390,7 +393,10 @@ def test_stage_lambda_database_parameter(stage_lambda, tmp_path):
             "status": "QUEUED",
             "source": {
                 "type": "database",
-                "parameterName": parameter_name,
+                "connection": {
+                    "type": "parameterStore",
+                    "parameterName": parameter_name,
+                },
                 "query": "SELECT value FROM parameters",
             },
         }


### PR DESCRIPTION
## Summary
- normalize database and warehouse source connections into a dedicated `connection` descriptor stored with jobs
- update the staging Lambda to resolve Secrets Manager and Parameter Store references defined in the new connection schema
- document the secure connection schema and refresh API and integration tests to exercise secret and parameter workflows

## Testing
- pytest services/api/tests tests/integration/test_stage_lambda.py

------
https://chatgpt.com/codex/tasks/task_e_68e6d507cabc8322b7367c27e7805d61