### PR TITLE
Add dashboard artifact previews and integration tests

### DIFF
--- a/dashboard/components/JobCard.tsx
+++ b/dashboard/components/JobCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import ArtifactBrowser from './ArtifactBrowser';
-import { fetchManifest, fetchResultLink } from '../lib/api';
+import ManifestPreview from './ManifestPreview';
+import { fetchManifest, fetchResultLink, ManifestPayload } from '../lib/api';
 import type { TrackedJob } from '../hooks/usePersistentJobs';
 
 interface JobCardProps {
@@ -12,7 +13,7 @@ interface JobCardProps {
 export function JobCard({ job, onRefresh, onRemove }: JobCardProps) {
   const [showArtifacts, setShowArtifacts] = useState(false);
   const [showManifest, setShowManifest] = useState(false);
-  const [manifest, setManifest] = useState<unknown>(null);
+  const [manifest, setManifest] = useState<ManifestPayload | null>(null);
   const [manifestError, setManifestError] = useState<string | null>(null);
   const [manifestLoading, setManifestLoading] = useState(false);
   const [resultUrl, setResultUrl] = useState<string | null>(null);
@@ -30,7 +31,7 @@ export function JobCard({ job, onRefresh, onRemove }: JobCardProps) {
       setManifestLoading(true);
       setManifestError(null);
       const response = await fetchManifest(job.jobId);
-      setManifest(response.manifest);
+      setManifest(response.manifest ?? null);
     } catch (error) {
       console.error('Failed to load manifest', error);
       setManifestError(error instanceof Error ? error.message : 'Unable to load manifest');
@@ -113,7 +114,7 @@ export function JobCard({ job, onRefresh, onRemove }: JobCardProps) {
           {manifestLoading && <p className="loading">Loading manifest…</p>}
           {manifestError && <div className="error-banner">{manifestError}</div>}
           {manifest && !manifestLoading && (
-            <pre>{JSON.stringify(manifest, null, 2)}</pre>
+            <ManifestPreview jobId={job.jobId} manifest={manifest} />
           )}
         </section>
       )}

--- a/dashboard/components/ManifestPreview.tsx
+++ b/dashboard/components/ManifestPreview.tsx
@@ -1,0 +1,257 @@
+import { useState } from 'react';
+import { fetchResultLink, ManifestArtifactEntry, ManifestPayload } from '../lib/api';
+
+interface ManifestPreviewProps {
+  jobId: string;
+  manifest: ManifestPayload;
+}
+
+interface ArtifactPreviewState {
+  kind: 'table' | 'image' | 'text' | 'json' | 'unsupported';
+  headers?: string[];
+  rows?: string[][];
+  src?: string;
+  text?: string;
+  reason?: string;
+}
+
+interface ArtifactPreviewCardProps {
+  jobId: string;
+  artifact: ManifestArtifactEntry;
+  basePath?: string;
+}
+
+function normalizeBasePath(jobId: string, basePath?: string): string {
+  if (basePath && basePath.startsWith('artifacts/')) {
+    return basePath.endsWith('/') ? basePath : `${basePath}/`;
+  }
+  return `artifacts/${jobId}/`;
+}
+
+function resultsRelativePath(jobId: string, artifact: ManifestArtifactEntry, basePath?: string): string | null {
+  if (!artifact.key) return null;
+  const base = normalizeBasePath(jobId, basePath);
+  if (!artifact.key.startsWith(base)) return null;
+  const relative = artifact.key.slice(base.length);
+  return relative.startsWith('results/') ? relative : null;
+}
+
+function truncateText(value: string, limit = 1000): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit)}…`;
+}
+
+function stripHtml(source: string): string {
+  return source.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function parseCsv(content: string, limit = 6): string[][] {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const rows: string[][] = [];
+  for (const line of lines) {
+    const parsed: string[] = [];
+    let field = '';
+    let inQuotes = false;
+    for (let index = 0; index < line.length; index += 1) {
+      const char = line[index];
+      if (char === '"') {
+        if (inQuotes && line[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        parsed.push(field);
+        field = '';
+      } else {
+        field += char;
+      }
+    }
+    parsed.push(field);
+    rows.push(parsed.map((value) => value.trim()));
+    if (rows.length >= limit) break;
+  }
+  return rows;
+}
+
+async function loadArtifactPreview(
+  jobId: string,
+  artifact: ManifestArtifactEntry,
+  basePath?: string,
+): Promise<ArtifactPreviewState> {
+  const contentType = (artifact.contentType ?? '').toLowerCase();
+  const relativePath = resultsRelativePath(jobId, artifact, basePath);
+  if (!relativePath) {
+    return { kind: 'unsupported', reason: 'Preview available for results artifacts only.' };
+  }
+
+  if (!contentType || /zip|octet-stream/.test(contentType)) {
+    return { kind: 'unsupported', reason: 'Preview not supported for this artifact type.' };
+  }
+
+  const { downloadUrl } = await fetchResultLink(jobId, relativePath);
+
+  if (contentType.startsWith('image/')) {
+    return { kind: 'image', src: downloadUrl };
+  }
+
+  const response = await fetch(downloadUrl, {
+    headers: { Range: 'bytes=0-65535' },
+  });
+  if (!response.ok) {
+    throw new Error('Unable to load artifact preview');
+  }
+  const text = await response.text();
+
+  if (contentType.includes('csv')) {
+    const rows = parseCsv(text);
+    if (rows.length === 0) {
+      return { kind: 'unsupported', reason: 'No rows available for preview.' };
+    }
+    const [header, ...data] = rows;
+    return { kind: 'table', headers: header, rows: data };
+  }
+
+  if (contentType.includes('json')) {
+    try {
+      const parsed = JSON.parse(text);
+      const formatted = JSON.stringify(parsed, null, 2);
+      return { kind: 'json', text: truncateText(formatted, 2000) };
+    } catch (error) {
+      return { kind: 'json', text: truncateText(text, 2000) };
+    }
+  }
+
+  if (contentType.includes('html')) {
+    return { kind: 'text', text: truncateText(stripHtml(text)) };
+  }
+
+  if (contentType.startsWith('text/')) {
+    return { kind: 'text', text: truncateText(text) };
+  }
+
+  return { kind: 'unsupported', reason: 'Preview not supported for this artifact type.' };
+}
+
+function ArtifactPreviewCard({ jobId, artifact, basePath }: ArtifactPreviewCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ArtifactPreviewState | null>(null);
+
+  const handleToggle = async () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (!next || preview || loading) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const loaded = await loadArtifactPreview(jobId, artifact, basePath);
+      setPreview(loaded);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load preview');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const title = artifact.name || artifact.key?.split('/').pop() || 'Artifact';
+  const description = artifact.description || 'Generated artifact';
+  const relative = resultsRelativePath(jobId, artifact, basePath);
+
+  return (
+    <article className="artifact-preview-card">
+      <header className="artifact-preview-card__header">
+        <div>
+          <h4>{title}</h4>
+          <p className="artifact-preview-description">{description}</p>
+          {relative && <p className="artifact-preview-path">{relative}</p>}
+        </div>
+        <div className="artifact-preview-actions">
+          <span className="artifact-preview-meta">{artifact.contentType ?? 'Unknown type'}</span>
+          <button type="button" onClick={handleToggle}>
+            {expanded ? 'Hide preview' : 'Show preview'}
+          </button>
+        </div>
+      </header>
+      {expanded && (
+        <div className="artifact-preview-body">
+          {loading && <p className="loading">Loading preview…</p>}
+          {error && <div className="error-banner">{error}</div>}
+          {preview && !loading && !error && (
+            <ArtifactPreviewContent preview={preview} title={title} />
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function ArtifactPreviewContent({ preview, title }: { preview: ArtifactPreviewState; title: string }) {
+  switch (preview.kind) {
+    case 'image':
+      return <img className="artifact-preview-image" src={preview.src ?? ''} alt={title} />;
+    case 'table':
+      return (
+        <table className="artifact-preview-table">
+          <thead>
+            <tr>
+              {(preview.headers ?? []).map((header) => (
+                <th key={header}>{header || '—'}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {(preview.rows ?? []).map((row, rowIndex) => (
+              <tr key={`${title}-row-${rowIndex}`}>
+                {row.map((cell, cellIndex) => (
+                  <td key={`${title}-cell-${rowIndex}-${cellIndex}`}>{cell || '—'}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    case 'json':
+      return <pre className="artifact-preview-text">{preview.text}</pre>;
+    case 'text':
+      return <pre className="artifact-preview-text">{preview.text}</pre>;
+    case 'unsupported':
+    default:
+      return <p className="artifact-preview-unsupported">{preview.reason ?? 'Preview unavailable.'}</p>;
+  }
+}
+
+export function ManifestPreview({ jobId, manifest }: ManifestPreviewProps) {
+  const artifacts = manifest.artifacts ?? [];
+  const basePath = manifest.basePath;
+
+  return (
+    <div className="manifest-preview">
+      <div className="manifest-summary">
+        <div>
+          <p className="eyebrow">Artifact manifest</p>
+          <h3>{artifacts.length ? `${artifacts.length} artifacts` : 'No artifacts yet'}</h3>
+        </div>
+        {manifest.basePath && <span className="artifact-preview-meta">Base path: {manifest.basePath}</span>}
+      </div>
+      <div className="artifact-preview-list">
+        {artifacts.length === 0 && <p className="empty-state">Artifacts will appear here once processing completes.</p>}
+        {artifacts.map((artifact) => (
+          <ArtifactPreviewCard
+            key={artifact.key ?? artifact.name}
+            jobId={jobId}
+            artifact={artifact}
+            basePath={basePath}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ManifestPreview;

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -30,9 +30,25 @@ export interface ArtifactListResponse {
   nextToken?: string | null;
 }
 
+export interface ManifestArtifactEntry {
+  name?: string;
+  description?: string;
+  contentType?: string;
+  key: string;
+  [key: string]: unknown;
+}
+
+export interface ManifestPayload {
+  jobId?: string;
+  basePath?: string;
+  artifacts?: ManifestArtifactEntry[];
+  dataQuality?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export interface ManifestResponse {
   jobId: string;
-  manifest: unknown;
+  manifest: ManifestPayload;
   etag?: string;
   contentLength?: number;
 }

--- a/dashboard/styles/globals.css
+++ b/dashboard/styles/globals.css
@@ -391,15 +391,122 @@ button.secondary {
 .manifest-viewer {
   background: rgba(15, 23, 42, 0.05);
   border-radius: 16px;
-  padding: 1rem;
-  max-height: 320px;
-  overflow: auto;
+  padding: 1.5rem;
 }
 
-.manifest-viewer pre {
+.manifest-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.manifest-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.manifest-summary h3 {
+  margin: 0.1rem 0 0;
+}
+
+.artifact-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.artifact-preview-card {
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.artifact-preview-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.artifact-preview-card h4 {
   margin: 0;
+  font-size: 1.05rem;
+}
+
+.artifact-preview-description,
+.artifact-preview-path {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.artifact-preview-path {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.artifact-preview-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  min-width: 140px;
+}
+
+.artifact-preview-meta {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.artifact-preview-body {
+  margin-top: 1rem;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.04);
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.artifact-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.artifact-preview-table th,
+.artifact-preview-table td {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.artifact-preview-table tbody tr:last-child th,
+.artifact-preview-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.artifact-preview-image {
+  max-width: 100%;
+  border-radius: 10px;
+  display: block;
+}
+
+.artifact-preview-text {
+  margin: 0;
+  white-space: pre-wrap;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
   font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.artifact-preview-unsupported {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
 
 .artifact-section {

--- a/lambdas/processor/handler.py
+++ b/lambdas/processor/handler.py
@@ -105,6 +105,12 @@ def _persist_artifact(bucket: str, key: str, spec: Mapping[str, Any]) -> None:
         headers = spec.get("headers", [])
         rows = spec.get("rows", [])
         body = _csv_bytes(list(headers), list(rows))
+    elif kind == "html":
+        html = spec.get("html", "")
+        if isinstance(html, bytes):
+            body = html
+        else:
+            body = str(html).encode("utf-8")
     elif kind == "image":
         data = spec.get("data", b"")
         if isinstance(data, memoryview):  # pragma: no cover - defensive conversion

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for MetricFoundry."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test helpers."""

--- a/tests/integration/test_processor_lambda.py
+++ b/tests/integration/test_processor_lambda.py
@@ -1,0 +1,171 @@
+import csv
+import importlib
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from .utils.aws import (
+    FakeDynamoResource,
+    FakeDynamoTable,
+    FakeS3,
+    FakeSSM,
+    FakeSecretsManager,
+)
+from .utils.langgraph import ensure_langgraph_stub
+
+
+SAMPLE_ROWS = [
+    {"id": index, "value": index * 2}
+    for index in range(1, 6)
+]
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def _csv_bytes(rows) -> bytes:
+    buffer = io.StringIO()
+    fieldnames = list(rows[0].keys())
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue().encode("utf-8")
+
+
+def _zip_bytes(name: str, payload: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(name, payload)
+    return buffer.getvalue()
+
+
+@pytest.fixture()
+def stage_and_processor(monkeypatch):
+    ensure_langgraph_stub()
+    monkeypatch.setenv("JOBS_TABLE", "jobs-table")
+    monkeypatch.setenv("ARTIFACTS_BUCKET", "artifacts-bucket")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+
+    stage_module = importlib.import_module("lambdas.stage.handler")
+    importlib.reload(stage_module)
+    processor_module = importlib.import_module("lambdas.processor.handler")
+    importlib.reload(processor_module)
+
+    fake_s3 = FakeS3()
+    fake_table = FakeDynamoTable()
+    fake_secrets = FakeSecretsManager()
+    fake_ssm = FakeSSM()
+
+    stage_module.s3 = fake_s3
+    stage_module.ddb = FakeDynamoResource(fake_table)
+    stage_module.secretsmanager = fake_secrets
+    stage_module.ssm = fake_ssm
+
+    processor_module.s3 = fake_s3
+    processor_module.ddb = FakeDynamoResource(fake_table)
+
+    return stage_module, processor_module, fake_s3, fake_table
+
+
+@pytest.mark.parametrize(
+    "filename, body_factory, content_type, expected_format, patch_parquet",
+    [
+        (
+            "dataset.csv",
+            lambda: _csv_bytes(SAMPLE_ROWS),
+            "text/csv",
+            "csv",
+            False,
+        ),
+        (
+            "dataset.parquet",
+            lambda: _csv_bytes(SAMPLE_ROWS),
+            "application/octet-stream",
+            "parquet",
+            True,
+        ),
+        (
+            "dataset.zip",
+            lambda: _zip_bytes("dataset.csv", _csv_bytes(SAMPLE_ROWS)),
+            "application/zip",
+            "zip",
+            False,
+        ),
+    ],
+)
+def test_stage_and_processor_pipeline(
+    stage_and_processor,
+    monkeypatch,
+    filename: str,
+    body_factory: Callable[[], bytes],
+    content_type: str,
+    expected_format: str,
+    patch_parquet: bool,
+):
+    stage_module, processor_module, fake_s3, fake_table = stage_and_processor
+    job_id = f"job-{expected_format}"
+    source_bucket = "incoming"
+    source_key = f"uploads/{filename}"
+    body = body_factory()
+
+    fake_table.put_item(
+        {
+            "pk": f"job#{job_id}",
+            "sk": "meta",
+            "status": "QUEUED",
+            "source": {"type": "upload", "bucket": source_bucket, "key": source_key},
+        }
+    )
+
+    fake_s3.put_object(Bucket=source_bucket, Key=source_key, Body=body, ContentType=content_type)
+
+    stage_result = stage_module.handler({"jobId": job_id}, None)
+    assert stage_result["metadata"]["format"] == expected_format
+
+    if patch_parquet:
+        graph_module = importlib.import_module("services.workers.graph.graph")
+
+        def _parquet_as_csv(data: bytes):
+            return graph_module._ingest_csv("dataset.parquet", data)
+
+        monkeypatch.setattr(graph_module, "_ingest_parquet", _parquet_as_csv)
+
+    response = processor_module.main({"jobId": job_id, "input": stage_result["input"]}, None)
+
+    assert response["ok"] is True
+    assert response["resultKey"].endswith("results.json")
+    assert response["manifestKey"].endswith("manifest.json")
+
+    record = fake_table.get_item({"pk": f"job#{job_id}", "sk": "meta"}).get("Item")
+    assert record is not None
+    assert record["status"] == processor_module.STATUS_SUCCEEDED
+    assert record["resultKey"] == response["resultKey"]
+    assert record["manifestKey"] == response["manifestKey"]
+
+    results_obj = fake_s3.get_object(Bucket=processor_module.ARTIFACTS_BUCKET, Key=response["resultKey"])
+    results_payload = json.loads(results_obj["Body"].read().decode("utf-8"))
+    assert results_payload["metrics"]["rows"] == len(SAMPLE_ROWS)
+    assert results_payload["metrics"]["columns"] == len(SAMPLE_ROWS[0])
+    assert results_payload["mlInference"]["status"] in {"failed", "skipped", "completed"}
+
+    manifest_obj = fake_s3.get_object(Bucket=processor_module.ARTIFACTS_BUCKET, Key=response["manifestKey"])
+    manifest = json.loads(manifest_obj["Body"].read().decode("utf-8"))
+    artifact_keys = {entry["key"] for entry in manifest["artifacts"]}
+    assert f"artifacts/{job_id}/results/results.json" in artifact_keys
+    assert f"artifacts/{job_id}/results/manifest.json" in artifact_keys
+    assert any(key.endswith("analytics_bundle.zip") for key in artifact_keys)
+
+    all_keys = list(fake_s3.list_keys(processor_module.ARTIFACTS_BUCKET, Prefix=f"artifacts/{job_id}/"))
+    assert f"artifacts/{job_id}/phases/ingest.json" in all_keys
+    assert response["resultKey"] in all_keys
+    assert response["manifestKey"] in all_keys

--- a/tests/integration/test_stage_lambda.py
+++ b/tests/integration/test_stage_lambda.py
@@ -1,137 +1,27 @@
 import importlib
 import io
 import json
-import hashlib
 import sqlite3
-from datetime import datetime, timezone
-from typing import Dict
+import sys
+from pathlib import Path
+import zipfile
 
 import pytest
-from botocore.exceptions import ClientError
+
+from .utils.aws import (
+    FakeDynamoResource,
+    FakeDynamoTable,
+    FakeS3,
+    FakeSSM,
+    FakeSecretsManager,
+)
 
 
-def _client_error(code: str, operation: str) -> ClientError:
-    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
-
-
-class FakeS3:
-    def __init__(self) -> None:
-        self._buckets: Dict[str, Dict[str, Dict[str, object]]] = {}
-
-    def _bucket(self, name: str) -> Dict[str, Dict[str, object]]:
-        return self._buckets.setdefault(name, {})
-
-    def put_object(self, Bucket: str, Key: str, Body, ContentType: str | None = None):
-        if isinstance(Body, str):
-            payload = Body.encode("utf-8")
-        elif hasattr(Body, "read"):
-            payload = Body.read()
-        else:
-            payload = bytes(Body)
-        metadata = {
-            "Body": payload,
-            "ContentLength": len(payload),
-            "ContentType": ContentType,
-            "LastModified": datetime.now(timezone.utc),
-            "ETag": hashlib.md5(payload).hexdigest(),
-        }
-        self._bucket(Bucket)[Key] = metadata
-        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
-
-    def copy_object(self, Bucket: str, Key: str, CopySource: Dict[str, str]):
-        source_bucket = CopySource["Bucket"]
-        source_key = CopySource["Key"]
-        source = self._bucket(source_bucket).get(source_key)
-        if source is None:
-            raise _client_error("NoSuchKey", "CopyObject")
-        copied = dict(source)
-        self._bucket(Bucket)[Key] = copied
-        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
-
-    def head_object(self, Bucket: str, Key: str):
-        bucket = self._bucket(Bucket)
-        if Key not in bucket:
-            raise _client_error("404", "HeadObject")
-        metadata = bucket[Key]
-        return {
-            "ContentLength": metadata["ContentLength"],
-            "ContentType": metadata.get("ContentType"),
-            "LastModified": metadata["LastModified"],
-        }
-
-    def get_object(self, Bucket: str, Key: str):
-        bucket = self._bucket(Bucket)
-        if Key not in bucket:
-            raise _client_error("NoSuchKey", "GetObject")
-        metadata = bucket[Key]
-        return {
-            "Body": io.BytesIO(metadata["Body"]),
-            "ContentLength": metadata["ContentLength"],
-            "ContentType": metadata.get("ContentType"),
-            "LastModified": metadata["LastModified"],
-        }
-
-
-class FakeDynamoTable:
-    def __init__(self) -> None:
-        self._items: Dict[tuple[str, str], Dict[str, object]] = {}
-
-    def put_item(self, Item: Dict[str, object]):
-        key = (Item["pk"], Item["sk"])
-        self._items[key] = dict(Item)
-        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
-
-    def get_item(self, Key: Dict[str, str]):
-        key = (Key["pk"], Key["sk"])
-        item = self._items.get(key)
-        return {"Item": dict(item)} if item else {}
-
-    def update_item(self, Key: Dict[str, str], UpdateExpression: str, ExpressionAttributeNames: Dict[str, str], ExpressionAttributeValues: Dict[str, object]):
-        key = (Key["pk"], Key["sk"])
-        if key not in self._items:
-            raise _client_error("ResourceNotFoundException", "UpdateItem")
-        item = dict(self._items[key])
-        expression = UpdateExpression.replace("SET", "").strip()
-        for part in expression.split(","):
-            name_alias, value_alias = [segment.strip() for segment in part.split("=", 1)]
-            attribute_name = ExpressionAttributeNames.get(name_alias, name_alias)
-            item[attribute_name] = ExpressionAttributeValues[value_alias]
-        self._items[key] = item
-        return {"Attributes": dict(item)}
-
-
-class FakeDynamoResource:
-    def __init__(self, table: FakeDynamoTable) -> None:
-        self._table = table
-
-    def Table(self, _name: str) -> FakeDynamoTable:  # noqa: N802 - mimic boto3
-        return self._table
-
-
-class FakeSecretsManager:
-    def __init__(self) -> None:
-        self._secrets: Dict[str, str] = {}
-
-    def put_secret(self, arn: str, value: str):
-        self._secrets[arn] = value
-
-    def get_secret_value(self, SecretId: str):  # noqa: N802 - mimic boto3
-        if SecretId not in self._secrets:
-            raise _client_error("ResourceNotFoundException", "GetSecretValue")
-        return {"ARN": SecretId, "SecretString": self._secrets[SecretId]}
-
-
-class FakeSSM:
-    def __init__(self) -> None:
-        self._parameters: Dict[str, str] = {}
-
-    def put_parameter(self, Name: str, Value: str):  # noqa: N802 - mimic boto3
-        self._parameters[Name] = Value
-
-    def get_parameter(self, Name: str, WithDecryption: bool = False):  # noqa: N802 - mimic boto3
-        if Name not in self._parameters:
-            raise _client_error("ParameterNotFound", "GetParameter")
-        return {"Parameter": {"Name": Name, "Value": self._parameters[Name]}}
+def _zip_bytes(name: str, content: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(name, content)
+    return buffer.getvalue()
 
 
 @pytest.fixture()
@@ -230,6 +120,14 @@ def test_stage_lambda_registers_warehouse_dialects(stage_lambda, monkeypatch):
             b"PARQUET",
             "application/octet-stream",
             "parquet",
+        ),
+        (
+            {"type": "upload", "bucket": "incoming", "key": "uploads/archive.zip"},
+            "incoming",
+            "uploads/archive.zip",
+            _zip_bytes("dataset.csv", b"id,value\n1,2\n"),
+            "application/zip",
+            "zip",
         ),
     ],
 )

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for integration tests."""
+
+__all__ = [
+    "aws",
+    "langgraph",
+]

--- a/tests/integration/utils/aws.py
+++ b/tests/integration/utils/aws.py
@@ -1,0 +1,175 @@
+"""Lightweight AWS service fakes for integration testing."""
+from __future__ import annotations
+
+import hashlib
+import io
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Optional
+
+from botocore.exceptions import ClientError
+
+
+__all__ = [
+    "client_error",
+    "FakeS3",
+    "FakeDynamoTable",
+    "FakeDynamoResource",
+    "FakeSecretsManager",
+    "FakeSSM",
+]
+
+
+def client_error(code: str, operation: str) -> ClientError:
+    """Create a botocore-style ClientError."""
+
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+class FakeS3:
+    """In-memory subset of the S3 API used by the lambdas."""
+
+    def __init__(self) -> None:
+        self._buckets: Dict[str, Dict[str, Dict[str, object]]] = {}
+
+    def _bucket(self, name: str) -> Dict[str, Dict[str, object]]:
+        return self._buckets.setdefault(name, {})
+
+    def put_object(
+        self,
+        Bucket: str,
+        Key: str,
+        Body,
+        ContentType: Optional[str] = None,
+    ) -> Dict[str, object]:  # noqa: N803 - mimic boto3 signature
+        if isinstance(Body, str):
+            payload = Body.encode("utf-8")
+        elif hasattr(Body, "read"):
+            payload = Body.read()
+        else:
+            payload = bytes(Body)
+        metadata = {
+            "Body": payload,
+            "ContentLength": len(payload),
+            "ContentType": ContentType,
+            "LastModified": datetime.now(timezone.utc),
+            "ETag": hashlib.md5(payload).hexdigest(),
+        }
+        self._bucket(Bucket)[Key] = metadata
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def copy_object(
+        self,
+        Bucket: str,
+        Key: str,
+        CopySource: Dict[str, str],
+    ) -> Dict[str, object]:  # noqa: N803 - mimic boto3 signature
+        source_bucket = CopySource["Bucket"]
+        source_key = CopySource["Key"]
+        source = self._bucket(source_bucket).get(source_key)
+        if source is None:
+            raise client_error("NoSuchKey", "CopyObject")
+        self._bucket(Bucket)[Key] = dict(source)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def head_object(self, Bucket: str, Key: str) -> Dict[str, object]:  # noqa: N803
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise client_error("404", "HeadObject")
+        metadata = bucket[Key]
+        return {
+            "ContentLength": metadata["ContentLength"],
+            "ContentType": metadata.get("ContentType"),
+            "LastModified": metadata["LastModified"],
+        }
+
+    def get_object(self, Bucket: str, Key: str) -> Dict[str, object]:  # noqa: N803
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise client_error("NoSuchKey", "GetObject")
+        metadata = bucket[Key]
+        return {
+            "Body": io.BytesIO(metadata["Body"]),
+            "ContentLength": metadata["ContentLength"],
+            "ContentType": metadata.get("ContentType"),
+            "LastModified": metadata["LastModified"],
+        }
+
+    def list_keys(self, Bucket: str, Prefix: str = "") -> Iterable[str]:  # noqa: N803
+        bucket = self._bucket(Bucket)
+        for key in sorted(bucket.keys()):
+            if key.startswith(Prefix):
+                yield key
+
+
+class FakeDynamoTable:
+    """Minimal DynamoDB table supporting put/get/update operations."""
+
+    def __init__(self) -> None:
+        self._items: Dict[tuple[str, str], Dict[str, object]] = {}
+
+    def put_item(self, Item: Dict[str, object]) -> Dict[str, object]:  # noqa: N803
+        key = (Item["pk"], Item["sk"])
+        self._items[key] = dict(Item)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_item(self, Key: Dict[str, str]) -> Dict[str, object]:  # noqa: N803
+        key = (Key["pk"], Key["sk"])
+        item = self._items.get(key)
+        return {"Item": dict(item)} if item else {}
+
+    def update_item(
+        self,
+        Key: Dict[str, str],
+        UpdateExpression: str,
+        ExpressionAttributeNames: Dict[str, str],
+        ExpressionAttributeValues: Dict[str, object],
+    ) -> Dict[str, object]:  # noqa: N803
+        key = (Key["pk"], Key["sk"])
+        if key not in self._items:
+            raise client_error("ResourceNotFoundException", "UpdateItem")
+        item = dict(self._items[key])
+        expression = UpdateExpression.replace("SET", "").strip()
+        for part in expression.split(","):
+            name_alias, value_alias = [segment.strip() for segment in part.split("=", 1)]
+            attribute_name = ExpressionAttributeNames.get(name_alias, name_alias)
+            item[attribute_name] = ExpressionAttributeValues[value_alias]
+        self._items[key] = item
+        return {"Attributes": dict(item)}
+
+
+class FakeDynamoResource:
+    def __init__(self, table: FakeDynamoTable) -> None:
+        self._table = table
+
+    def Table(self, _name: str) -> FakeDynamoTable:  # noqa: N802 - mimic boto3
+        return self._table
+
+
+class FakeSecretsManager:
+    def __init__(self) -> None:
+        self._secrets: Dict[str, str] = {}
+
+    def put_secret(self, arn: str, value: str) -> None:
+        self._secrets[arn] = value
+
+    def get_secret_value(self, SecretId: str) -> Dict[str, object]:  # noqa: N803
+        if SecretId not in self._secrets:
+            raise client_error("ResourceNotFoundException", "GetSecretValue")
+        return {"ARN": SecretId, "SecretString": self._secrets[SecretId]}
+
+
+class FakeSSM:
+    def __init__(self) -> None:
+        self._parameters: Dict[str, str] = {}
+
+    def put_parameter(self, Name: str, Value: str) -> None:  # noqa: N803
+        self._parameters[Name] = Value
+
+    def get_parameter(
+        self,
+        Name: str,
+        WithDecryption: bool = False,
+    ) -> Dict[str, object]:  # noqa: N803
+        if Name not in self._parameters:
+            raise client_error("ParameterNotFound", "GetParameter")
+        return {"Parameter": {"Name": Name, "Value": self._parameters[Name]}}

--- a/tests/integration/utils/langgraph.py
+++ b/tests/integration/utils/langgraph.py
@@ -1,0 +1,72 @@
+"""Helpers for working with the LangGraph dependency during tests."""
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import List
+
+
+__all__ = ["ensure_langgraph_stub"]
+
+
+def ensure_langgraph_stub() -> None:
+    """Provide a very small stub of ``langgraph`` when the dependency is absent."""
+
+    try:
+        importlib.import_module("langgraph.graph")
+        return
+    except Exception:  # pragma: no cover - stub fallback path
+        pass
+
+    pkg = ModuleType("langgraph")
+    mod = ModuleType("langgraph.graph")
+
+    END = object()
+
+    class _CompiledGraph:
+        def __init__(self, nodes, order):
+            self._nodes = nodes
+            self._order = order
+
+        def invoke(self, initial_state):
+            state = dict(initial_state)
+            for name in self._order:
+                update = self._nodes[name](state)
+                if update:
+                    state.update(update)
+            return state
+
+    class StateGraph:
+        def __init__(self, _state_type):
+            self._nodes = {}
+            self._edges = {}
+            self._entry = None
+
+        def add_node(self, name, func):
+            self._nodes[name] = func
+
+        def set_entry_point(self, name):
+            self._entry = name
+
+        def add_edge(self, source, dest):
+            self._edges.setdefault(source, []).append(dest)
+
+        def compile(self):
+            order: List[str] = []
+            current = self._entry
+            visited: set[str] = set()
+            while current is not None and current != END:
+                if current in visited:
+                    raise RuntimeError("cycle detected in stub graph")
+                visited.add(current)
+                order.append(current)
+                next_nodes = self._edges.get(current, [])
+                current = next_nodes[0] if next_nodes else None
+            return _CompiledGraph(self._nodes, order)
+
+    mod.END = END
+    mod.StateGraph = StateGraph
+    pkg.graph = mod
+    sys.modules["langgraph"] = pkg
+    sys.modules["langgraph.graph"] = mod


### PR DESCRIPTION
## Summary
- add an inline manifest preview component that renders artifact tables, text, and images inside the dashboard job card
- extend dashboard API typings and styles to support manifest previews and persist HTML artifacts in the processor lambda
- introduce shared AWS fakes and run new processor/stage lambda integration tests covering CSV, Parquet, and ZIP inputs

## Testing
- pytest tests/integration/test_stage_lambda.py tests/integration/test_processor_lambda.py


------
https://chatgpt.com/codex/tasks/task_e_68e6f49f643083228d179ceade7531b5