### PR TITLE
Integrate real analytics pipeline into API

### DIFF
--- a/services/api/app.py
+++ b/services/api/app.py
@@ -1,15 +1,13 @@
 # services/api/app.py
 from __future__ import annotations
 
-import io
 import json
 import logging
 import os
 import time
 import uuid
-import zipfile
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -17,6 +15,13 @@ from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 from pydantic import BaseModel
+
+from services.common.pipeline import (
+    build_results_payload,
+    persist_pipeline_outputs,
+    result_key_for,
+    summarize_phase_payload,
+)
 
 # ---- Env ----
 BUCKET_NAME = os.environ["BUCKET_NAME"]          # artifacts bucket
@@ -551,280 +556,143 @@ def presign_any(job_id: str, key: str = Query(..., description="Full S3 key insi
 # --- Dev/manual processing endpoint to emit the full artifact layout ---
 @app.post("/jobs/{job_id}/process")
 def process_now(job_id: str):
-    """
-    Emits the structure described in the Result Package Overview:
+    """Run the LangGraph analytics pipeline immediately for the given job."""
 
-    artifacts/{jobId}/
-      manifest.json
-      phases/
-        01_ingest.json
-        02_profiling.json
-        03_quality.json
-        04_descriptives.json
-        05_narrative.json
-        99_finalize.json
-      results/
-        results.json
-        manifest.json
-        descriptive_stats.csv
-        descriptiveTable.json
-        correlations.csv
-        outliers.json
-        report.html
-        report.txt
-        graphs/
-          hist_1.png
-          scatter_1.png
-        bundles/
-          analytics_bundle.zip
-          visualizations.zip
-    """
     job = ensure_job(job_id)
-    src = job.get("source") or {}
-    bucket = src.get("bucket")
-    key    = src.get("key")
+    source = job.get("source") or {}
+    bucket = source.get("bucket")
+    key = source.get("key")
     if not (bucket and key):
         raise HTTPException(status_code=400, detail="job has no source.bucket/key")
 
-    ddb_update_status(job_id, "RUNNING")
-    now_iso = datetime.now(timezone.utc).isoformat()
+    try:
+        from services.workers.graph.graph import PHASE_ORDER, run_pipeline  # type: ignore import
+    except Exception as exc:  # pragma: no cover - dependency missing in unusual setups
+        logger.exception("analytics pipeline unavailable", extra={"job_id": job_id})
+        raise HTTPException(status_code=500, detail="Analytics pipeline is not available") from exc
+
+    dimensions = {"SourceType": source.get("type", "unknown")}
+    result_key = result_key_for(job_id)
 
     try:
-        # --- Read input to compute basic stats (demo) ---
-        obj = s3.get_object(Bucket=bucket, Key=key)
-        body_stream = obj["Body"]
-        line_count = 0
-        data_bytes = 0
-        for chunk in iter(lambda: body_stream.read(1024 * 1024), b""):
-            line_count += chunk.count(b"\n")
-            data_bytes += len(chunk)
-        if data_bytes > 0:
-            line_count = max(1, line_count)
-        rows = max(0, line_count - 1)
-        columns = 2  # demo; a real pipeline should infer
+        phase_count = len(PHASE_ORDER)
+        try:
+            ddb_update_status(
+                job_id,
+                "RUNNING",
+                currentPhase=PHASE_ORDER[0] if PHASE_ORDER else "ingest",
+                phaseIndex=0,
+                phaseCount=phase_count,
+                progress=0,
+            )
+        except Exception as exc:
+            logger.warning("failed to mark job running", extra={"job_id": job_id, "error": str(exc)})
 
-        base = f"artifacts/{job_id}"
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code in ("404", "NotFound", "NoSuchKey"):
+                raise HTTPException(status_code=404, detail="Input object not found")
+            raise HTTPException(status_code=502, detail="Unable to read job input") from exc
 
-        # --- Phase files ---
-        phases = [
-            ("01_ingest.json", {
-                "phase": "ingest",
-                "input": {"bucket": bucket, "key": key, "bytes": data_bytes},
-                "status": "completed", "at": now_iso,
-            }),
-            ("02_profiling.json", {
-                "phase": "profiling",
-                "summary": {"rows": rows, "columns": columns},
-                "status": "completed", "at": now_iso,
-            }),
-            ("03_quality.json", {
-                "phase": "data_quality",
-                "checks": [{"name": "non_empty", "status": "pass"}],
-                "status": "completed", "at": now_iso,
-            }),
-            ("04_descriptives.json", {
-                "phase": "descriptive_stats",
-                "tables": [{"name": "descriptive_stats", "path": f"s3://{BUCKET_NAME}/{base}/results/descriptive_stats.csv"}],
-                "status": "completed", "at": now_iso,
-            }),
-            ("05_narrative.json", {
-                "phase": "nl_report",
-                "highlights": [
-                    f"Dataset has {rows} rows and {columns} columns.",
-                    "Strongest correlations and potential outliers summarized in report.",
-                ],
-                "status": "completed", "at": now_iso,
-            }),
-            ("99_finalize.json", {"phase": "finalization", "status": "completed", "at": now_iso}),
-        ]
-        for fname, payload in phases:
+        body = obj.get("Body")
+        if body is None:
+            raise HTTPException(status_code=502, detail="Job input body missing")
+
+        def _on_phase(phase: str, payload: Mapping[str, Any], index: int, total: int) -> None:
+            progress = int(((index + 1) / max(total, 1)) * 100)
+            summary = summarize_phase_payload(payload)
+            update: Dict[str, Any] = {
+                "currentPhase": phase,
+                "phaseIndex": index,
+                "phaseCount": total,
+                "progress": progress,
+            }
+            if summary:
+                update["phaseSummary"] = summary
+            try:
+                ddb_update_status(job_id, "RUNNING", **update)
+            except Exception as exc:
+                logger.warning(
+                    "failed to stream phase update",
+                    extra={"job_id": job_id, "phase": phase, "error": str(exc)},
+                )
+
+        try:
+            result = run_pipeline(
+                job_id,
+                {"bucket": bucket, "key": key},
+                body,
+                artifact_prefix=f"artifacts/{job_id}",
+                on_phase=_on_phase,
+            )
+        finally:
+            closer = getattr(body, "close", None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception:
+                    pass
+
+        artifact_keys = persist_pipeline_outputs(job_id, BUCKET_NAME, result, s3_client=s3)
+        results_payload = build_results_payload(
+            job_id,
+            result,
+            source_input={"bucket": bucket, "key": key},
+            artifact_bucket=BUCKET_NAME,
+        )
+        s3.put_object(
+            Bucket=BUCKET_NAME,
+            Key=result_key,
+            Body=json.dumps(results_payload, indent=2, default=str).encode("utf-8"),
+            ContentType="application/json",
+        )
+
+        try:
+            ddb_update_status(
+                job_id,
+                "SUCCEEDED",
+                resultKey=result_key,
+                manifestKey=artifact_keys.get("manifest"),
+                completedAt=epoch(),
+            )
+        except Exception as exc:
+            logger.warning("failed to persist SUCCEEDED status", extra={"job_id": job_id, "error": str(exc)})
+
+        record_metric("JobProcessed", dimensions=dimensions)
+        return {
+            "jobId": job_id,
+            "resultKey": result_key,
+            "manifestKey": artifact_keys.get("manifest"),
+            "results": results_payload,
+        }
+
+    except HTTPException:
+        record_metric("JobProcessingFailed", dimensions=dimensions)
+        raise
+    except Exception as exc:
+        logger.exception("analytics pipeline failed", extra={"job_id": job_id})
+        err_txt = f"{type(exc).__name__}: {exc}"
+        try:
+            ddb_update_status(job_id, "FAILED", error=err_txt[:1000])
+        except Exception as update_exc:
+            logger.warning("failed to persist FAILED status", extra={"job_id": job_id, "error": str(update_exc)})
+
+        try:
+            error_key = result_key.replace("results.json", "error.json")
             s3.put_object(
                 Bucket=BUCKET_NAME,
-                Key=f"{base}/phases/{fname}",
-                Body=json.dumps(payload, indent=2).encode("utf-8"),
+                Key=error_key,
+                Body=json.dumps({"jobId": job_id, "error": err_txt}, indent=2, default=str).encode("utf-8"),
                 ContentType="application/json",
             )
+        except Exception as write_exc:
+            logger.warning("failed to write error artifact", extra={"job_id": job_id, "error": str(write_exc)})
 
-        # --- Top-level manifest (dev/debug) ---
-        manifest = {
-            "jobId": job_id,
-            "generatedAt": now_iso,
-            "input": {"bucket": bucket, "key": key, "bytes": data_bytes},
-            "phases": [f"s3://{BUCKET_NAME}/{base}/phases/{n}" for (n, _) in phases],
-        }
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/manifest.json",
-            Body=json.dumps(manifest, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
+        record_metric("JobProcessingFailed", dimensions=dimensions)
+        raise HTTPException(status_code=500, detail="Failed to process job") from exc
 
-        # --- Results: descriptive_stats.csv (demo single-row per column) ---
-        desc_csv = [
-            "column,count,mean,std,min,p5,p25,p50,p75,p95,max",
-            "a,100,50.0,10.0,10,20,40,50,60,80,90",
-            "b,100,25.0,5.0,5,10,20,25,30,40,45",
-        ]
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/descriptive_stats.csv",
-            Body=("\n".join(desc_csv) + "\n").encode("utf-8"),
-            ContentType="text/csv",
-        )
-        # JSON version for in-app rendering convenience
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/descriptiveTable.json",
-            Body=json.dumps({
-                "columns": ["column","count","mean","std","min","p5","p25","p50","p75","p95","max"],
-                "rows": [
-                    {"column":"a","count":100,"mean":50.0,"std":10.0,"min":10,"p5":20,"p25":40,"p50":50,"p75":60,"p95":80,"max":90},
-                    {"column":"b","count":100,"mean":25.0,"std":5.0,"min":5,"p5":10,"p25":20,"p50":25,"p75":30,"p95":40,"max":45},
-                ]
-            }, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
-
-        # --- Results: correlations.csv ---
-        corr_csv = [
-            "feature_x,feature_y,pearson_r,n",
-            "a,b,0.71,100",
-        ]
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/correlations.csv",
-            Body=("\n".join(corr_csv) + "\n").encode("utf-8"),
-            ContentType="text/csv",
-        )
-
-        # --- Results: outliers.json (z-score demo) ---
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/outliers.json",
-            Body=json.dumps({
-                "method":"zscore","threshold":3.0,
-                "findings":[
-                    {"column":"a","value":90,"z":3.2,"index":92},
-                    {"column":"b","value":45,"z":3.1,"index":77},
-                ]
-            }, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
-
-        # --- Report (HTML + TXT) ---
-        html = f"""<!doctype html>
-<html><head><meta charset="utf-8"><title>MetricFoundry Report</title>
-<style>body{{font-family:ui-sans-serif,system-ui;max-width:920px;margin:24px auto;padding:0 16px}}
-h1{{font-size:22px}} .kpi{{display:inline-block;margin-right:16px;padding:8px 12px;border:1px solid #ddd;border-radius:10px}}</style></head>
-<body>
-  <h1>Descriptive report — Job {job_id}</h1>
-  <div class="kpi">Rows: <b>{rows}</b></div>
-  <div class="kpi">Columns: <b>{columns}</b></div>
-  <p>Generated: {now_iso}</p>
-  <p><b>Highlights:</b> strongest correlation a↔b (r≈0.71); 2 potential outliers found (z≥3).</p>
-</body></html>"""
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/report.html",
-            Body=html.encode("utf-8"),
-            ContentType="text/html",
-        )
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/report.txt",
-            Body=f"Job {job_id}\nRows: {rows}\nColumns: {columns}\nGenerated: {now_iso}\n".encode("utf-8"),
-            ContentType="text/plain",
-        )
-
-        # --- Graphs (PNG stubs) ---
-        png_stub = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x05\x00\x00\x00\x05\x08\x06\x00\x00\x00\x8d\x89\x1d\r\x00\x00\x00\x0cIDATx\x9ccddbf\xa0\x040\x00\x00\x05\x00\x01\x9b\xc7\x19\xd3\x00\x00\x00\x00IEND\xaeB`\x82"
-        s3.put_object(Bucket=BUCKET_NAME, Key=f"{base}/results/graphs/hist_1.png", Body=png_stub, ContentType="image/png")
-        s3.put_object(Bucket=BUCKET_NAME, Key=f"{base}/results/graphs/scatter_1.png", Body=png_stub, ContentType="image/png")
-
-        # --- Results manifest (enumerate user-facing deliverables) ---
-        results_manifest = {
-            "jobId": job_id,
-            "generatedAt": now_iso,
-            "artifacts": [
-                {"key": f"{base}/results/descriptive_stats.csv", "contentType":"text/csv"},
-                {"key": f"{base}/results/descriptiveTable.json", "contentType":"application/json"},
-                {"key": f"{base}/results/correlations.csv", "contentType":"text/csv"},
-                {"key": f"{base}/results/outliers.json", "contentType":"application/json"},
-                {"key": f"{base}/results/report.html", "contentType":"text/html"},
-                {"key": f"{base}/results/report.txt", "contentType":"text/plain"},
-                {"key": f"{base}/results/graphs/hist_1.png", "contentType":"image/png"},
-                {"key": f"{base}/results/graphs/scatter_1.png", "contentType":"image/png"},
-            ]
-        }
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/manifest.json",
-            Body=json.dumps(results_manifest, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
-
-        # --- results.json (canonical API summary) ---
-        results_json = {
-            "jobId": job_id,
-            "summary": {"rows": rows, "columns": columns},
-            "links": {
-                "manifest": f"s3://{BUCKET_NAME}/{base}/manifest.json",
-                "resultsManifest": f"s3://{BUCKET_NAME}/{base}/results/manifest.json",
-                "input": f"s3://{bucket}/{key}",
-                "reportHtml": f"s3://{BUCKET_NAME}/{base}/results/report.html",
-            },
-            "generatedAt": now_iso,
-        }
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/results.json",
-            Body=json.dumps(results_json, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
-
-        # --- Bundles (analytics + visualizations) ---
-        # analytics_bundle.zip: CSV/JSON diagnostics
-        mem = io.BytesIO()
-        with zipfile.ZipFile(mem, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr("descriptive_stats.csv", "\n".join(desc_csv) + "\n")
-            zf.writestr("correlations.csv", "\n".join(corr_csv) + "\n")
-            zf.writestr("outliers.json", json.dumps({
-                "method":"zscore","threshold":3.0,"findings":[
-                    {"column":"a","value":90,"z":3.2,"index":92},
-                    {"column":"b","value":45,"z":3.1,"index":77},
-                ]
-            }, indent=2))
-        mem.seek(0)
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/bundles/analytics_bundle.zip",
-            Body=mem.read(),
-            ContentType="application/zip",
-        )
-
-        # visualizations.zip: PNG graphs
-        mem2 = io.BytesIO()
-        with zipfile.ZipFile(mem2, mode="w", compression=zipfile.ZIP_DEFLATED) as zf2:
-            zf2.writestr("graphs/hist_1.png", png_stub)
-            zf2.writestr("graphs/scatter_1.png", png_stub)
-        mem2.seek(0)
-        s3.put_object(
-            Bucket=BUCKET_NAME,
-            Key=f"{base}/results/bundles/visualizations.zip",
-            Body=mem2.read(),
-            ContentType="application/zip",
-        )
-
-        # success
-        results_key = f"{base}/results/results.json"
-        ddb_update_status(job_id, "SUCCEEDED", resultKey=results_key)
-        return {"ok": True, "resultKey": results_key}
-    except Exception as e:
-        ddb_update_status(job_id, "FAILED", error=str(e)[:1000])
-        raise
-
-
-# ---- Middleware ----
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
     start = time.time()

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for MetricFoundry services."""

--- a/services/common/pipeline.py
+++ b/services/common/pipeline.py
@@ -1,0 +1,241 @@
+"""Helpers for working with MetricFoundry's analytics pipeline outputs."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for static typing
+    from services.workers.graph.graph import PipelineResult
+else:  # pragma: no cover - at runtime we treat PipelineResult as ``Any``
+    PipelineResult = Any  # type: ignore[misc,assignment]
+
+
+ANALYSIS_VERSION = "2024.05"
+
+
+def result_key_for(job_id: str) -> str:
+    return f"artifacts/{job_id}/results/results.json"
+
+
+def manifest_key_for(job_id: str) -> str:
+    return f"artifacts/{job_id}/results/manifest.json"
+
+
+def phase_key_for(job_id: str, phase: str) -> str:
+    return f"artifacts/{job_id}/phases/{phase}.json"
+
+
+def artifact_key_for(job_id: str, relative: str) -> str:
+    return f"artifacts/{job_id}/{relative}"
+
+
+def _json_bytes(data: Any) -> bytes:
+    return json.dumps(data, indent=2, default=str).encode("utf-8")
+
+
+def _csv_bytes(headers: Iterable[str], rows: Iterable[Mapping[str, Any]]) -> bytes:
+    output = io.StringIO()
+    fieldnames = list(headers)
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({name: row.get(name, "") for name in fieldnames})
+    return output.getvalue().encode("utf-8")
+
+
+def _bytes_for_artifact(spec: Mapping[str, Any]) -> bytes:
+    kind = spec.get("kind")
+    if kind == "json":
+        return _json_bytes(spec.get("data"))
+    if kind == "text":
+        text = spec.get("text", "")
+        if isinstance(text, bytes):
+            return text
+        return str(text).encode("utf-8")
+    if kind == "csv":
+        headers = spec.get("headers", [])
+        rows = spec.get("rows", [])
+        return _csv_bytes(list(headers), list(rows))
+    if kind == "html":
+        html = spec.get("html")
+        if isinstance(html, bytes):
+            return html
+        return str(html or spec.get("text", "")).encode("utf-8")
+    if kind in {"image", "binary"}:
+        data = spec.get("data", b"")
+        if isinstance(data, memoryview):  # pragma: no cover - defensive conversion
+            data = data.tobytes()
+        if not isinstance(data, (bytes, bytearray)):
+            raise ValueError("Binary artifact data must be bytes-like")
+        return bytes(data)
+    raise ValueError(f"Unsupported artifact kind: {kind}")
+
+
+def _content_type_for_artifact(relative_key: str, spec: Mapping[str, Any]) -> str:
+    value = spec.get("contentType")
+    if isinstance(value, str) and value:
+        return value
+    kind = spec.get("kind")
+    if kind == "json":
+        return "application/json"
+    if kind == "text":
+        return "text/plain"
+    if kind == "csv":
+        return "text/csv"
+    if kind == "html":
+        return "text/html"
+    if kind == "image":
+        return "image/png"
+    if relative_key.endswith(".zip"):
+        return "application/zip"
+    if relative_key.endswith(".png"):
+        return "image/png"
+    if relative_key.endswith(".json"):
+        return "application/json"
+    if relative_key.endswith(".csv"):
+        return "text/csv"
+    if relative_key.endswith(".html"):
+        return "text/html"
+    return "application/octet-stream"
+
+
+def persist_pipeline_outputs(
+    job_id: str,
+    bucket: str,
+    result: "PipelineResult",
+    *,
+    s3_client,
+) -> Dict[str, str]:
+    """Upload phase payloads and generated artifacts to S3.
+
+    Returns a mapping that includes the manifest key and phase artifact keys.
+    """
+
+    uploaded: Dict[str, str] = {}
+    for phase, payload in result.phases.items():
+        key = phase_key_for(job_id, phase)
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=_json_bytes(payload),
+            ContentType="application/json",
+        )
+        uploaded[f"phase:{phase}"] = key
+
+    for relative_key, spec in result.artifact_contents.items():
+        key = artifact_key_for(job_id, relative_key)
+        body = _bytes_for_artifact(spec)
+        content_type = _content_type_for_artifact(relative_key, spec)
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ContentType=content_type,
+        )
+
+    manifest_key = manifest_key_for(job_id)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=manifest_key,
+        Body=_json_bytes(result.manifest),
+        ContentType="application/json",
+    )
+    uploaded["manifest"] = manifest_key
+    return uploaded
+
+
+def summarize_phase_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary: Dict[str, Any] = {}
+    text = payload.get("summary")
+    if isinstance(text, str):
+        summary["summary"] = text
+    metrics = payload.get("metrics")
+    if isinstance(metrics, Mapping):
+        summary["metrics"] = dict(metrics)
+    dq_score = payload.get("datasetCompleteness")
+    if dq_score is not None:
+        summary["datasetCompleteness"] = dq_score
+    if summary:
+        return summary
+    keys = list(payload.keys())[:5]
+    return {"fields": keys}
+
+
+def build_results_payload(
+    job_id: str,
+    result: "PipelineResult",
+    *,
+    source_input: Optional[Mapping[str, Any]] = None,
+    artifact_bucket: Optional[str] = None,
+    analysis_version: str = ANALYSIS_VERSION,
+) -> Dict[str, Any]:
+    metrics = dict(result.metrics)
+    summary = {
+        "rows": metrics.get("rows"),
+        "columns": metrics.get("columns"),
+        "bytesRead": metrics.get("bytesRead"),
+        "datasetCompleteness": metrics.get("datasetCompleteness"),
+        "dqScore": metrics.get("dqScore"),
+    }
+    summary = {key: value for key, value in summary.items() if value is not None}
+
+    links: Dict[str, str] = {}
+    if source_input:
+        bucket = source_input.get("bucket")
+        key = source_input.get("key")
+        if bucket and key:
+            links["input"] = f"s3://{bucket}/{key}"
+
+    if artifact_bucket:
+        links["resultsManifest"] = f"s3://{artifact_bucket}/{manifest_key_for(job_id)}"
+        links["resultsJson"] = f"s3://{artifact_bucket}/{result_key_for(job_id)}"
+
+    profile_phase = result.phases.get("profile", {})
+    schema: List[Dict[str, Any]] = []
+    if isinstance(profile_phase, Mapping):
+        columns = profile_phase.get("columnProfiles")
+        if isinstance(columns, list):
+            for column in columns:
+                if not isinstance(column, Mapping):
+                    continue
+                name = column.get("name")
+                if name is None:
+                    continue
+                entry: Dict[str, Any] = {"name": str(name)}
+                inferred = column.get("inferredType")
+                if inferred is not None:
+                    entry["type"] = inferred
+                schema.append(entry)
+
+    payload = {
+        "jobId": job_id,
+        "analysisVersion": analysis_version,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "schema": schema,
+        "links": links,
+        "phases": result.phases,
+        "metrics": metrics,
+        "correlations": result.correlations,
+        "outliers": result.outliers,
+        "mlInference": result.ml_inference,
+        "artifactManifest": result.manifest,
+        "phaseArtifactKeys": {phase: phase_key_for(job_id, phase) for phase in result.phases},
+    }
+
+    return payload
+
+
+__all__ = [
+    "ANALYSIS_VERSION",
+    "artifact_key_for",
+    "build_results_payload",
+    "manifest_key_for",
+    "persist_pipeline_outputs",
+    "phase_key_for",
+    "result_key_for",
+    "summarize_phase_payload",
+]


### PR DESCRIPTION
## Summary
- replace the /jobs/{jobId}/process stub with a real invocation of the LangGraph analytics pipeline and persist genuine artifacts
- extract shared helpers for manifest generation, artifact uploads, and results payload construction into services/common/pipeline and reuse them in the processor Lambda
- extend the API integration suite with a stubbed pipeline to verify that processing writes artifacts, updates DynamoDB status, and surfaces results
- document the analytics pipeline's supported formats, defensive behaviours, and current connector landscape in the README so operators understand the system's capabilities and limits

## Testing
- pytest tests/integration/test_api_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68e83d6b5da08322ad326095d2d2c589