### PR TITLE
Integrate real analytics pipeline into API

### DIFF
--- a/dashboard/components/UploadForm.tsx
+++ b/dashboard/components/UploadForm.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useRef, useState } from "react";
 
-type OnJobCreated = () => Promise<{
+type OnJobCreated = (file: File | Blob) => Promise<{
   jobId: string;
   upload: (file: File | Blob) => Promise<void>;
 }>;
@@ -32,7 +32,7 @@ export default function UploadForm({
       try {
         setBusy("creating");
         setLocalMsg("Creating job…");
-        const { upload } = await onJobCreated();
+        const { upload } = await onJobCreated(file);
 
         setBusy("uploading");
         setLocalMsg("Uploading dataset…");

--- a/dashboard/pages/index.tsx
+++ b/dashboard/pages/index.tsx
@@ -97,10 +97,10 @@ export default function DashboardHome() {
     [],
   );
 
-  const handleJobCreated = useCallback(async () => {
+  const handleJobCreated = useCallback(async (file: File | Blob) => {
     setGlobalError(null);
     try {
-      const resp = await createUploadJob();
+      const resp = await createUploadJob(file);
       const jobId = resp.jobId;
       addJob({
         jobId,
@@ -283,8 +283,8 @@ export default function DashboardHome() {
 
           <div className="hero-actions">
             <UploadForm
-              onJobCreated={async () => {
-                const { jobId, uploadUrl } = await handleJobCreated();
+              onJobCreated={async (file) => {
+                const { jobId, uploadUrl } = await handleJobCreated(file);
                 return {
                   jobId,
                   upload: async (file: File | Blob) => {

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for MetricFoundry services."""

--- a/services/common/pipeline.py
+++ b/services/common/pipeline.py
@@ -1,0 +1,241 @@
+"""Helpers for working with MetricFoundry's analytics pipeline outputs."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for static typing
+    from services.workers.graph.graph import PipelineResult
+else:  # pragma: no cover - at runtime we treat PipelineResult as ``Any``
+    PipelineResult = Any  # type: ignore[misc,assignment]
+
+
+ANALYSIS_VERSION = "2024.05"
+
+
+def result_key_for(job_id: str) -> str:
+    return f"artifacts/{job_id}/results/results.json"
+
+
+def manifest_key_for(job_id: str) -> str:
+    return f"artifacts/{job_id}/results/manifest.json"
+
+
+def phase_key_for(job_id: str, phase: str) -> str:
+    return f"artifacts/{job_id}/phases/{phase}.json"
+
+
+def artifact_key_for(job_id: str, relative: str) -> str:
+    return f"artifacts/{job_id}/{relative}"
+
+
+def _json_bytes(data: Any) -> bytes:
+    return json.dumps(data, indent=2, default=str).encode("utf-8")
+
+
+def _csv_bytes(headers: Iterable[str], rows: Iterable[Mapping[str, Any]]) -> bytes:
+    output = io.StringIO()
+    fieldnames = list(headers)
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({name: row.get(name, "") for name in fieldnames})
+    return output.getvalue().encode("utf-8")
+
+
+def _bytes_for_artifact(spec: Mapping[str, Any]) -> bytes:
+    kind = spec.get("kind")
+    if kind == "json":
+        return _json_bytes(spec.get("data"))
+    if kind == "text":
+        text = spec.get("text", "")
+        if isinstance(text, bytes):
+            return text
+        return str(text).encode("utf-8")
+    if kind == "csv":
+        headers = spec.get("headers", [])
+        rows = spec.get("rows", [])
+        return _csv_bytes(list(headers), list(rows))
+    if kind == "html":
+        html = spec.get("html")
+        if isinstance(html, bytes):
+            return html
+        return str(html or spec.get("text", "")).encode("utf-8")
+    if kind in {"image", "binary"}:
+        data = spec.get("data", b"")
+        if isinstance(data, memoryview):  # pragma: no cover - defensive conversion
+            data = data.tobytes()
+        if not isinstance(data, (bytes, bytearray)):
+            raise ValueError("Binary artifact data must be bytes-like")
+        return bytes(data)
+    raise ValueError(f"Unsupported artifact kind: {kind}")
+
+
+def _content_type_for_artifact(relative_key: str, spec: Mapping[str, Any]) -> str:
+    value = spec.get("contentType")
+    if isinstance(value, str) and value:
+        return value
+    kind = spec.get("kind")
+    if kind == "json":
+        return "application/json"
+    if kind == "text":
+        return "text/plain"
+    if kind == "csv":
+        return "text/csv"
+    if kind == "html":
+        return "text/html"
+    if kind == "image":
+        return "image/png"
+    if relative_key.endswith(".zip"):
+        return "application/zip"
+    if relative_key.endswith(".png"):
+        return "image/png"
+    if relative_key.endswith(".json"):
+        return "application/json"
+    if relative_key.endswith(".csv"):
+        return "text/csv"
+    if relative_key.endswith(".html"):
+        return "text/html"
+    return "application/octet-stream"
+
+
+def persist_pipeline_outputs(
+    job_id: str,
+    bucket: str,
+    result: "PipelineResult",
+    *,
+    s3_client,
+) -> Dict[str, str]:
+    """Upload phase payloads and generated artifacts to S3.
+
+    Returns a mapping that includes the manifest key and phase artifact keys.
+    """
+
+    uploaded: Dict[str, str] = {}
+    for phase, payload in result.phases.items():
+        key = phase_key_for(job_id, phase)
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=_json_bytes(payload),
+            ContentType="application/json",
+        )
+        uploaded[f"phase:{phase}"] = key
+
+    for relative_key, spec in result.artifact_contents.items():
+        key = artifact_key_for(job_id, relative_key)
+        body = _bytes_for_artifact(spec)
+        content_type = _content_type_for_artifact(relative_key, spec)
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ContentType=content_type,
+        )
+
+    manifest_key = manifest_key_for(job_id)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=manifest_key,
+        Body=_json_bytes(result.manifest),
+        ContentType="application/json",
+    )
+    uploaded["manifest"] = manifest_key
+    return uploaded
+
+
+def summarize_phase_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary: Dict[str, Any] = {}
+    text = payload.get("summary")
+    if isinstance(text, str):
+        summary["summary"] = text
+    metrics = payload.get("metrics")
+    if isinstance(metrics, Mapping):
+        summary["metrics"] = dict(metrics)
+    dq_score = payload.get("datasetCompleteness")
+    if dq_score is not None:
+        summary["datasetCompleteness"] = dq_score
+    if summary:
+        return summary
+    keys = list(payload.keys())[:5]
+    return {"fields": keys}
+
+
+def build_results_payload(
+    job_id: str,
+    result: "PipelineResult",
+    *,
+    source_input: Optional[Mapping[str, Any]] = None,
+    artifact_bucket: Optional[str] = None,
+    analysis_version: str = ANALYSIS_VERSION,
+) -> Dict[str, Any]:
+    metrics = dict(result.metrics)
+    summary = {
+        "rows": metrics.get("rows"),
+        "columns": metrics.get("columns"),
+        "bytesRead": metrics.get("bytesRead"),
+        "datasetCompleteness": metrics.get("datasetCompleteness"),
+        "dqScore": metrics.get("dqScore"),
+    }
+    summary = {key: value for key, value in summary.items() if value is not None}
+
+    links: Dict[str, str] = {}
+    if source_input:
+        bucket = source_input.get("bucket")
+        key = source_input.get("key")
+        if bucket and key:
+            links["input"] = f"s3://{bucket}/{key}"
+
+    if artifact_bucket:
+        links["resultsManifest"] = f"s3://{artifact_bucket}/{manifest_key_for(job_id)}"
+        links["resultsJson"] = f"s3://{artifact_bucket}/{result_key_for(job_id)}"
+
+    profile_phase = result.phases.get("profile", {})
+    schema: List[Dict[str, Any]] = []
+    if isinstance(profile_phase, Mapping):
+        columns = profile_phase.get("columnProfiles")
+        if isinstance(columns, list):
+            for column in columns:
+                if not isinstance(column, Mapping):
+                    continue
+                name = column.get("name")
+                if name is None:
+                    continue
+                entry: Dict[str, Any] = {"name": str(name)}
+                inferred = column.get("inferredType")
+                if inferred is not None:
+                    entry["type"] = inferred
+                schema.append(entry)
+
+    payload = {
+        "jobId": job_id,
+        "analysisVersion": analysis_version,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "schema": schema,
+        "links": links,
+        "phases": result.phases,
+        "metrics": metrics,
+        "correlations": result.correlations,
+        "outliers": result.outliers,
+        "mlInference": result.ml_inference,
+        "artifactManifest": result.manifest,
+        "phaseArtifactKeys": {phase: phase_key_for(job_id, phase) for phase in result.phases},
+    }
+
+    return payload
+
+
+__all__ = [
+    "ANALYSIS_VERSION",
+    "artifact_key_for",
+    "build_results_payload",
+    "manifest_key_for",
+    "persist_pipeline_outputs",
+    "phase_key_for",
+    "result_key_for",
+    "summarize_phase_payload",
+]

--- a/tests/integration/test_api_workflow.py
+++ b/tests/integration/test_api_workflow.py
@@ -1,15 +1,18 @@
 import asyncio
 import importlib
+import io
 import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Dict, List, Optional
 
 import httpx
 import pytest
 from botocore.exceptions import ClientError
 
+from tests.integration.utils.langgraph import ensure_langgraph_stub
 
 def _client_error(code: str, operation: str) -> ClientError:
     return ClientError({"Error": {"Code": code, "Message": code}}, operation)
@@ -88,6 +91,7 @@ class FakeTable:
 class FakeS3:
     def __init__(self) -> None:
         self._objects: Dict[str, Dict[str, Dict[str, object]]] = {}
+        self.presigned: List[Dict[str, object]] = []
 
     def _bucket(self, name: str) -> Dict[str, Dict[str, object]]:
         return self._objects.setdefault(name, {})
@@ -109,6 +113,8 @@ class FakeS3:
         return {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
     def generate_presigned_url(self, ClientMethod: str, Params: Dict[str, str], ExpiresIn: int):  # noqa: N803 - mimic boto3 casing
+        record = {"ClientMethod": ClientMethod, "Params": dict(Params), "ExpiresIn": ExpiresIn}
+        self.presigned.append(record)
         return f"https://example.com/{Params['Key']}?expires={ExpiresIn}&method={ClientMethod}"
 
     def list_objects_v2(self, Bucket: str, Prefix: str, MaxKeys: int, Delimiter: Optional[str] = "/", **_: object):  # noqa: N803
@@ -152,6 +158,14 @@ class FakeS3:
             "ETag": metadata.get("ETag"),
         }
 
+    def get_object(self, Bucket: str, Key: str):
+        bucket = self._bucket(Bucket)
+        if Key not in bucket:
+            raise _client_error("404", "GetObject")
+        metadata = bucket[Key]
+        body = io.BytesIO(metadata.get("Body", b""))
+        return {"Body": body, "ContentLength": metadata.get("Size")}
+
 
 class ApiClient:
     def __init__(self, app):
@@ -176,6 +190,7 @@ class ApiClient:
 
 @pytest.fixture()
 def api_app(monkeypatch):
+    ensure_langgraph_stub()
     monkeypatch.setenv("BUCKET_NAME", "artifacts-bucket")
     monkeypatch.setenv("TABLE_NAME", "jobs-table")
     monkeypatch.setenv("STATE_MACHINE_ARN", "arn:aws:states:region:acct:stateMachine:jobs")
@@ -194,6 +209,54 @@ def api_app(monkeypatch):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
     module = importlib.import_module("services.api.app")
     importlib.reload(module)
+
+    graph_module = importlib.import_module("services.workers.graph.graph")
+    stub_phase_order = ["ingest", "profile", "descriptive_stats", "nl_report", "finalize"]
+
+    def _stub_run_pipeline(job_id, source, body, *, artifact_prefix, on_phase=None):
+        phases = {
+            "ingest": {"summary": "ingested", "rows": 2, "sourceFormat": "csv"},
+            "profile": {"columnProfiles": [{"name": "value", "inferredType": "integer"}]},
+            "descriptive_stats": {"metrics": {"rows": 2}},
+            "nl_report": {"summary": "Report"},
+            "finalize": {"summary": "done"},
+        }
+        if on_phase:
+            for index, phase in enumerate(stub_phase_order):
+                on_phase(phase, phases.get(phase, {}), index, len(stub_phase_order))
+
+        artifact_contents = {
+            "results/descriptive_stats.csv": {
+                "kind": "csv",
+                "headers": ["column", "count"],
+                "rows": [{"column": "value", "count": 2}],
+            },
+            "results/report.txt": {"kind": "text", "text": "analysis"},
+            "results/report.html": {"kind": "html", "html": "<p>analysis</p>"},
+            "results/bundles/analytics_bundle.zip": {"kind": "binary", "data": b"bundle"},
+            "results/bundles/visualizations.zip": {"kind": "binary", "data": b"viz"},
+        }
+
+        manifest = {
+            "jobId": job_id,
+            "artifacts": [
+                {"key": f"{artifact_prefix}/results/results.json"},
+                {"key": f"{artifact_prefix}/results/manifest.json"},
+            ],
+        }
+
+        return SimpleNamespace(
+            phases=phases,
+            metrics={"rows": 2, "columns": 1, "bytesRead": 20},
+            manifest=manifest,
+            artifact_contents=artifact_contents,
+            correlations=[],
+            outliers=[],
+            ml_inference={"status": "skipped"},
+        )
+
+    monkeypatch.setattr(graph_module, "PHASE_ORDER", stub_phase_order)
+    monkeypatch.setattr(graph_module, "run_pipeline", _stub_run_pipeline)
 
     fake_s3 = FakeS3()
     fake_table = FakeTable()
@@ -237,6 +300,51 @@ def test_create_job_enqueues_state_machine(api_app):
     metric_names = [metric["MetricName"] for metric in cloudwatch.metrics]
     assert "JobQueued" in metric_names
     assert "JobCreated" in metric_names
+
+
+def test_create_job_honours_filename_and_content_type(api_app):
+    client, module, s3, table, sfn, _cloudwatch = api_app
+
+    response = client.post(
+        "/jobs",
+        json={
+            "source_type": "upload",
+            "source_config": {
+                "filename": "../My Data.PARQUET",
+                "contentType": "application/octet-stream",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    key = payload["source"]["key"]
+    assert key.endswith("/input/My_Data.PARQUET")
+    assert payload["source"]["filename"] == "My_Data.PARQUET"
+    assert payload["source"]["contentType"] == "application/octet-stream"
+
+    presign_first = s3.presigned[-1]
+    assert presign_first["Params"]["Key"] == key
+    assert presign_first["Params"]["ContentType"] == "application/octet-stream"
+
+    response_no_type = client.post(
+        "/jobs",
+        json={"source_type": "upload", "source_config": {"filename": " spaces..jsonl "}},
+    )
+
+    assert response_no_type.status_code == 200
+    payload_no_type = response_no_type.json()
+    key_no_type = payload_no_type["source"]["key"]
+    assert key_no_type.endswith("/input/spaces.jsonl")
+    assert payload_no_type["source"]["filename"] == "spaces.jsonl"
+
+    presign_second = s3.presigned[-1]
+    assert presign_second["Params"]["Key"] == key_no_type
+    assert "ContentType" not in presign_second["Params"]
+
+    # Ensure job metadata stored the sanitized filename
+    record = table._items[(f"job#{payload_no_type['jobId']}", "meta")]
+    assert record["source"]["filename"] == "spaces.jsonl"
 
 
 def test_create_job_handles_state_machine_failure(api_app):
@@ -304,3 +412,55 @@ def test_artifact_and_results_endpoints(api_app):
     download_body = download.json()
     assert download_body["key"].endswith("results.json")
     assert download_body["downloadUrl"].startswith("https://example.com/")
+
+
+def test_process_now_runs_pipeline(api_app):
+    client, module, s3, table, _sfn, cloudwatch = api_app
+
+    job_id = "job-process"
+    source_bucket = "incoming"
+    source_key = "uploads/data.csv"
+
+    table.put_item(
+        {
+            "pk": f"job#{job_id}",
+            "sk": "meta",
+            "status": "QUEUED",
+            "createdAt": 1700000100,
+            "updatedAt": 1700000100,
+            "source": {"type": "upload", "bucket": source_bucket, "key": source_key},
+        }
+    )
+
+    s3.put_object(
+        Bucket=source_bucket,
+        Key=source_key,
+        Body="id,value\n1,2\n2,3\n",
+        ContentType="text/csv",
+    )
+
+    response = client.post(f"/jobs/{job_id}/process")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jobId"] == job_id
+    assert body["resultKey"].endswith("results/results.json")
+    assert body["manifestKey"].endswith("results/manifest.json")
+
+    record = table._items[(f"job#{job_id}", "meta")]
+    assert record["status"] == "SUCCEEDED"
+    assert record["resultKey"] == body["resultKey"]
+    assert record["manifestKey"] == body["manifestKey"]
+
+    artifacts_bucket = module.BUCKET_NAME
+    artifact_keys = sorted(s3._objects.get(artifacts_bucket, {}).keys())
+    assert f"artifacts/{job_id}/phases/ingest.json" in artifact_keys
+    assert body["resultKey"] in artifact_keys
+    assert f"artifacts/{job_id}/results/bundles/analytics_bundle.zip" in artifact_keys
+
+    results_payload = body["results"]
+    assert results_payload["metrics"]["rows"] == 2
+    assert results_payload["summary"]["columns"] == 1
+    assert results_payload["links"]["resultsJson"].endswith("results/results.json")
+
+    metric_names = [metric["MetricName"] for metric in cloudwatch.metrics]
+    assert "JobProcessed" in metric_names


### PR DESCRIPTION
## Summary
- replace the /jobs/{jobId}/process stub with a real invocation of the LangGraph analytics pipeline and persist genuine artifacts
- extract shared helpers for manifest generation, artifact uploads, and results payload construction into services/common/pipeline and reuse them in the processor Lambda
- extend the API integration suite with a stubbed pipeline to verify that processing writes artifacts, updates DynamoDB status, and surfaces results
- document the analytics pipeline's supported formats, defensive behaviours, and current connector landscape in the README so operators understand the system's capabilities and limits
- allow upload jobs to preserve filenames and optional content types when issuing presigned URLs so arbitrary datasets can be uploaded without signature errors

## Testing
- pytest tests/integration/test_api_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68e83d6b5da08322ad326095d2d2c589