### PR TITLE
Stream worker inputs and secure remote invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ large files may still exceed the Lambda's available memory or timeout budget,
 but those cases surface explicit failure events and error artifacts so you can
 iterate safely.
 
+Remote deployments can further constrain ingestion footprint via the
+`MAX_PIPELINE_BODY_BYTES` environment variable (default 512 MiB). The LangGraph
+worker enforces this limit before materialising staged S3 bodies, preventing
+out-of-memory crashes while giving operators a tunable ceiling that matches their
+runtime budgets.
+
 ## API hardening & observability
 
 The FastAPI service fronts the ingestion workflow and exposes endpoints for

--- a/infra/stacks/core.ts
+++ b/infra/stacks/core.ts
@@ -1,5 +1,5 @@
 // infra/stacks/core.ts
-import { Stack, StackProps, Duration, RemovalPolicy, CfnOutput } from "aws-cdk-lib";
+import { Stack, StackProps, Duration, RemovalPolicy, CfnOutput, Size } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as path from "path";
 import { execSync } from "child_process";
@@ -147,19 +147,49 @@ export class MetricFoundryCoreStack extends Stack {
     // Processor Lambda: runs analytics pipeline after staging completes
     // Copies repo-local `services/` into the bundle so imports work.
     // =====================================================================
-    const processorCodePath = path.join(__dirname, "../../lambdas/processor");
-    const repoRoot = path.join(__dirname, "../../");
-    const servicesDir = path.join(repoRoot, "services");
+    const workerInvokeMode =
+      (this.node.tryGetContext("workerInvokeMode") as string | undefined) ?? "embedded";
+    const workerArn = this.node.tryGetContext("workerArn") as string | undefined;
+    const workerUrl = this.node.tryGetContext("workerUrl") as string | undefined;
+    const workerAuthHeader = this.node.tryGetContext("workerAuthHeader") as string | undefined;
+    const workerBearerToken = this.node.tryGetContext("workerBearerToken") as string | undefined;
+
+    const processorEnv: Record<string, string> = {
+      JOBS_TABLE: this.jobsTable.tableName,
+      TABLE_NAME: this.jobsTable.tableName,
+      ARTIFACTS_BUCKET: this.artifacts.bucketName,
+      WORKER_INVOKE_MODE: workerInvokeMode,
+    };
+
+    if (workerArn) {
+      processorEnv["WORKER_ARN"] = workerArn;
+    }
+    if (workerUrl) {
+      processorEnv["WORKER_URL"] = workerUrl;
+    }
+    if (workerAuthHeader) {
+      processorEnv["WORKER_AUTH_HEADER"] = workerAuthHeader;
+    }
+    if (workerBearerToken) {
+      processorEnv["WORKER_BEARER_TOKEN"] = workerBearerToken;
+    }
 
     const processorFn = new lambda.DockerImageFunction(this, "ProcessorFn", {
-  code: lambda.DockerImageCode.fromImageAsset("lambdas/processor"), // path directly to folder
-  timeout: Duration.minutes(15),
-  memorySize: 3008,
-  environment: {
-    JOBS_TABLE: this.jobsTable.tableName,
-    ARTIFACTS_BUCKET: this.artifacts.bucketName,
-  },
-});
+      code: lambda.DockerImageCode.fromImageAsset("lambdas/processor"), // path directly to folder
+      timeout: Duration.minutes(15),
+      memorySize: 3008,
+      environment: processorEnv,
+      ephemeralStorageSize: Size.mebibytes(10240),
+    });
+
+    if (workerArn) {
+      processorFn.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
+          resources: [workerArn],
+        })
+      );
+    }
 
     this.artifacts.grantReadWrite(processorFn);
     this.jobsTable.grantReadWriteData(processorFn);
@@ -193,11 +223,13 @@ export class MetricFoundryCoreStack extends Stack {
       resultPath: sfn.JsonPath.DISCARD,
     });
 
-    const stageFailed = new sfn.Fail(this, "StageFailed");
-    stageTask.addCatch(markStageFailed.next(stageFailed), {
-      errors: ["States.ALL"],
-      resultPath: "$.stageError",
-    });
+    stageTask.addCatch(
+      markStageFailed.next(new sfn.Fail(this, "StageFailed")),
+      {
+        errors: ["States.ALL"],
+        resultPath: "$.stageError",
+      }
+    );
 
     const processTask = new tasks.LambdaInvoke(this, "ProcessJob", {
       lambdaFunction: processorFn,
@@ -225,8 +257,10 @@ export class MetricFoundryCoreStack extends Stack {
       resultPath: "$.processError",
     });
 
+    const finalizeState = new sfn.Succeed(this, "Finalize");
+
     this.jobsStateMachine = new sfn.StateMachine(this, "JobsStateMachine", {
-      definition: stageTask.next(processTask),
+      definition: stageTask.next(processTask).next(finalizeState),
       timeout: Duration.minutes(15),
     });
 

--- a/lambdas/processor/Dockerfile
+++ b/lambdas/processor/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Copy function code
+COPY services ${LAMBDA_TASK_ROOT}/services
 COPY handler.py ${LAMBDA_TASK_ROOT}
 
 # Command is handler.handler (the Python function)

--- a/lambdas/processor/handler.py
+++ b/lambdas/processor/handler.py
@@ -1,30 +1,44 @@
-import csv
-import io
+import base64
 import json
 import os
 import time
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
 
 import boto3
-from botocore.exceptions import ClientError
 
-from services.workers.graph.graph import PHASE_ORDER, PipelineResult, run_pipeline
+from services.common.pipeline import (
+    build_results_payload,
+    emit_parse_debug,
+    object_exists,
+    persist_pipeline_outputs,
+    error_key_for,
+    result_key_for,
+    summarize_phase_payload,
+)
+from services.workers.graph.graph import (
+    PHASE_ORDER,
+    PipelineResult,
+    decode_pipeline_result,
+    run_pipeline,
+)
 
 s3 = boto3.client("s3")
 ddb = boto3.resource("dynamodb")
+lambda_client = boto3.client("lambda")
 
 TABLE_NAME = os.environ["JOBS_TABLE"]
 ARTIFACTS_BUCKET = os.environ.get("ARTIFACTS_BUCKET")
-
-ANALYSIS_VERSION = "TEST-2025-10-09"
-
+WORKER_INVOKE_MODE = os.environ.get("WORKER_INVOKE_MODE", "embedded").strip().lower()
+WORKER_ARN = os.environ.get("WORKER_ARN")
+WORKER_URL = os.environ.get("WORKER_URL")
+WORKER_AUTH_HEADER = os.environ.get("WORKER_AUTH_HEADER")
+WORKER_BEARER_TOKEN = os.environ.get("WORKER_BEARER_TOKEN")
 
 STATUS_RUNNING = "RUNNING"
 STATUS_SUCCEEDED = "SUCCEEDED"
 STATUS_FAILED = "FAILED"
-
-ANALYSIS_VERSION = "2024.05"
 
 
 def ddb_table():
@@ -53,101 +67,6 @@ def ddb_upsert_status(job_id: str, status: str, **attrs) -> None:
     )
 
 
-def result_key_for(job_id: str) -> str:
-    return f"artifacts/{job_id}/results/results.json"
-
-
-def manifest_key_for(job_id: str) -> str:
-    return f"artifacts/{job_id}/results/manifest.json"
-
-
-def phase_key_for(job_id: str, phase: str) -> str:
-    return f"artifacts/{job_id}/phases/{phase}.json"
-
-
-def artifact_key_for(job_id: str, relative: str) -> str:
-    return f"artifacts/{job_id}/{relative}"
-
-
-def object_exists(bucket: str, key: str) -> bool:
-    try:
-        s3.head_object(Bucket=bucket, Key=key)
-        return True
-    except ClientError as e:
-        code = e.response.get("Error", {}).get("Code")
-        if code in ("404", "NotFound", "NoSuchKey"):
-            return False
-        raise
-
-
-def _json_bytes(data: Any) -> bytes:
-    return json.dumps(data, indent=2, default=str).encode("utf-8")
-
-
-def _csv_bytes(headers: list[str], rows: list[Mapping[str, Any]]) -> bytes:
-    output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=headers)
-    writer.writeheader()
-    for row in rows:
-        writer.writerow({h: row.get(h, "") for h in headers})
-    return output.getvalue().encode("utf-8")
-
-
-def _put_object(bucket: str, key: str, body: bytes, content_type: str) -> None:
-    s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType=content_type)
-
-
-def _persist_artifact(bucket: str, key: str, spec: Mapping[str, Any]) -> None:
-    kind = spec.get("kind")
-    content_type = spec.get("contentType", "application/octet-stream")
-    if kind == "json":
-        body = _json_bytes(spec.get("data"))
-    elif kind == "text":
-        text = spec.get("text", "")
-        body = text.encode("utf-8")
-    elif kind == "csv":
-        headers = spec.get("headers", [])
-        rows = spec.get("rows", [])
-        body = _csv_bytes(list(headers), list(rows))
-    elif kind == "html":
-        html = spec.get("html", "")
-        if isinstance(html, bytes):
-            body = html
-        else:
-            body = str(html).encode("utf-8")
-    elif kind == "image":
-        data = spec.get("data", b"")
-        if isinstance(data, memoryview):  # pragma: no cover - defensive conversion
-            data = data.tobytes()
-        if not isinstance(data, (bytes, bytearray)):
-            raise ValueError("Image artifact data must be bytes-like")
-        body = bytes(data)
-    elif kind == "binary":
-        data = spec.get("data", b"")
-        if isinstance(data, memoryview):
-            data = data.tobytes()
-        if not isinstance(data, (bytes, bytearray)):
-            raise ValueError("Binary artifact data must be bytes-like")
-        body = bytes(data)
-    else:
-        raise ValueError(f"Unsupported artifact kind: {kind}")
-    _put_object(bucket, key, body, content_type)
-
-
-def _summarize_phase_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
-    summary: Dict[str, Any] = {}
-    if "summary" in payload and isinstance(payload["summary"], str):
-        summary["summary"] = payload["summary"]
-    if "metrics" in payload and isinstance(payload["metrics"], Mapping):
-        summary["metrics"] = payload["metrics"]
-    if "datasetCompleteness" in payload:
-        summary["datasetCompleteness"] = payload["datasetCompleteness"]
-    if not summary:
-        keys = list(payload.keys())[:5]
-        summary["fields"] = keys
-    return summary
-
-
 def _default_callback(job_id: str):
     def _callback(phase: str, payload: Mapping[str, Any], index: int, total: int) -> None:
         progress = int(((index + 1) / total) * 100)
@@ -159,7 +78,7 @@ def _default_callback(job_id: str):
                 phaseIndex=index,
                 phaseCount=total,
                 progress=progress,
-                phaseSummary=_summarize_phase_payload(payload),
+                phaseSummary=summarize_phase_payload(payload),
             )
         except Exception as exc:  # pragma: no cover - DynamoDB errors shouldn't halt job
             print(f"[ProcessorFn] Warning: failed to stream phase status for {phase}: {exc}")
@@ -167,168 +86,231 @@ def _default_callback(job_id: str):
     return _callback
 
 
-def _persist_pipeline_outputs(job_id: str, bucket: str, result: PipelineResult) -> Dict[str, str]:
-    phase_keys: Dict[str, str] = {}
-    for phase, payload in result.phases.items():
-        key = phase_key_for(job_id, phase)
-        _put_object(bucket, key, _json_bytes(payload), "application/json")
-        phase_keys[phase] = key
-
-    for relative, spec in result.artifact_contents.items():
-        key = artifact_key_for(job_id, relative)
-        _persist_artifact(bucket, key, spec)
-
-    manifest_key = manifest_key_for(job_id)
-    _put_object(bucket, manifest_key, _json_bytes(result.manifest), "application/json")
-
-    return {"manifest": manifest_key, **{f"phase:{k}": v for k, v in phase_keys.items()}}
+def _is_embedded_mode() -> bool:
+    return WORKER_INVOKE_MODE in {"", "embedded", "local"}
 
 
-def _build_schema_from_profile(profile_phase: Mapping[str, Any]) -> List[Dict[str, Any]]:
-    schema: List[Dict[str, Any]] = []
-    columns = profile_phase.get("columnProfiles")
-    if not isinstance(columns, list):
-        return schema
-    for item in columns:
-        if not isinstance(item, Mapping):
-            continue
-        name = item.get("name")
-        if name is None:
-            continue
-        entry: Dict[str, Any] = {"name": str(name)}
-        inferred = item.get("inferredType")
-        if inferred is not None:
-            entry["type"] = inferred
-        schema.append(entry)
-    return schema
-
-
-def _emit_parse_debug(job_id: str, bucket: str, profile_phase: Mapping[str, Any]) -> Optional[str]:
-    """
-    Write a tiny debug artifact so we can see what the parser actually produced.
-    Looks for common keys emitted by a profiler node.
-    """
-    try:
-        debug: Dict[str, Any] = {}
-        # shape / dtypes
-        shape = profile_phase.get("shape")
-        if isinstance(shape, Mapping):
-            debug["shape"] = {k: int(v) for k, v in shape.items() if isinstance(v, int)}
-        dtypes = profile_phase.get("dtypes")
-        if isinstance(dtypes, Mapping):
-            debug["dtypes"] = {str(k): str(v) for k, v in dtypes.items()}
-        # head preview
-        head = profile_phase.get("head")
-        if isinstance(head, list):
-            debug["head"] = head[:3]
-        # fallback: column names
-        cols = profile_phase.get("columnProfiles")
-        if isinstance(cols, list):
-            debug["columnNames"] = [
-                str(c.get("name")) for c in cols if isinstance(c, Mapping) and c.get("name")
-            ][:50]
-        key = artifact_key_for(job_id, "results/parse_debug.json")
-        _put_object(bucket, key, _json_bytes(debug), "application/json")
-        return key
-    except Exception:
+def _worker_callback_payload(job_id: str) -> Optional[Dict[str, Any]]:
+    if _is_embedded_mode():
         return None
 
+    table_name = os.environ.get("TABLE_NAME") or TABLE_NAME
+    if table_name:
+        return {"mode": "ddb", "table": table_name, "jobId": job_id}
+    return {"mode": "log", "jobId": job_id}
 
-def build_results_payload(
+
+def _ensure_bytes(data: Any) -> bytes:
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return bytes(data)
+
+    reader = getattr(data, "read", None)
+    if callable(reader):
+        chunks = bytearray()
+        chunk_size = 8 * 1024 * 1024
+        while True:
+            try:
+                piece = reader(chunk_size)
+            except TypeError:
+                piece = reader()
+            if not piece:
+                break
+            if isinstance(piece, memoryview):
+                piece = piece.tobytes()
+            elif isinstance(piece, bytearray):
+                piece = bytes(piece)
+            if not isinstance(piece, (bytes, bytearray)):
+                raise TypeError("Stream produced non-bytes payload")
+            chunks.extend(piece)
+        return bytes(chunks)
+
+    raise TypeError(f"Unsupported body type: {type(data).__name__}")
+
+
+def _build_worker_event(
     job_id: str,
-    result: PipelineResult,
+    source: Mapping[str, Any],
+    artifact_prefix: str,
     *,
-    source_input: Optional[Mapping[str, Any]] = None,
-    artifact_bucket: Optional[str] = None,
+    body_bytes: Optional[bytes] = None,
+    body_s3: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, Any]:
-    metrics = dict(result.metrics)
-    profile_phase = result.phases.get("profile", {}) or {}
-
-    # Build schema BEFORE summary so we can use it for robust fallbacks
-    schema = _build_schema_from_profile(profile_phase)
-
-    # Best-effort fallbacks for rows/columns (avoid numeric-only mistakes)
-    def _rows_fallback() -> Optional[int]:
-        # common shapes produced by profilers
-        for k in ("rowCount", "rows", "nRows", "shapeRows"):
-            v = profile_phase.get(k)
-            if isinstance(v, int) and v >= 0:
-                return v
-        # sometimes embedded under "shape" or "metrics"
-        shp = profile_phase.get("shape")
-        if isinstance(shp, Mapping) and isinstance(shp.get("rows"), int):
-            return shp["rows"]
-        m = profile_phase.get("metrics")
-        if isinstance(m, Mapping) and isinstance(m.get("rows"), int):
-            return m["rows"]
-        return None
-
-    def _cols_fallback() -> Optional[int]:
-        # most reliable: the length of the built schema
-        if schema:
-            return len(schema)
-        for k in ("columnCount", "columns", "nCols", "shapeCols"):
-            v = profile_phase.get(k)
-            if isinstance(v, int) and v >= 0:
-                return v
-        shp = profile_phase.get("shape")
-        if isinstance(shp, Mapping) and isinstance(shp.get("columns"), int):
-            return shp["columns"]
-        cols = profile_phase.get("columnProfiles")
-        if isinstance(cols, list):
-            return len(cols)
-        return None
-
-    rows_val = metrics.get("rows")
-    cols_val = metrics.get("columns")
-    if not isinstance(rows_val, int):
-        fb = _rows_fallback()
-        if isinstance(fb, int):
-            rows_val = fb
-    if not isinstance(cols_val, int):
-        fb = _cols_fallback()
-        if isinstance(fb, int):
-            cols_val = fb
-
-    summary = {
-        "rows": rows_val,
-        "columns": cols_val,
-        "bytesRead": metrics.get("bytesRead"),
-        "datasetCompleteness": metrics.get("datasetCompleteness"),
-        "dqScore": metrics.get("dqScore"),
-    }
-    summary = {key: value for key, value in summary.items() if value is not None}
-
-    links: Dict[str, str] = {}
-    if source_input:
-        src_bucket = source_input.get("bucket")
-        src_key = source_input.get("key")
-        if src_bucket and src_key:
-            links["input"] = f"s3://{src_bucket}/{src_key}"
-
-    if artifact_bucket:
-        manifest_uri = f"s3://{artifact_bucket}/{manifest_key_for(job_id)}"
-        results_uri = f"s3://{artifact_bucket}/{result_key_for(job_id)}"
-        links["resultsManifest"] = manifest_uri
-        links["resultsJson"] = results_uri
-
-    payload = {
+    payload: Dict[str, Any] = {
         "jobId": job_id,
-        "analysisVersion": ANALYSIS_VERSION,
-        "generatedAt": datetime.now(timezone.utc).isoformat(),
-        "summary": summary,
-        "schema": schema,
-        "links": links,
-        "phases": result.phases,
-        "metrics": metrics,
-        "correlations": result.correlations,
-        "outliers": result.outliers,
-        "mlInference": result.ml_inference,
-        "artifactManifest": result.manifest,
-        "phaseArtifactKeys": {phase: phase_key_for(job_id, phase) for phase in result.phases},
+        "source": dict(source),
+        "artifactPrefix": artifact_prefix,
     }
-
+    if body_bytes is not None:
+        payload["body"] = base64.b64encode(body_bytes).decode("ascii")
+    if body_s3:
+        payload["bodyS3"] = dict(body_s3)
+    callback_cfg = _worker_callback_payload(job_id)
+    if callback_cfg:
+        payload["callback"] = callback_cfg
     return payload
+
+
+def _invoke_worker_lambda(
+    job_id: str,
+    source: Mapping[str, Any],
+    artifact_prefix: str,
+    *,
+    body_bytes: Optional[bytes] = None,
+    body_s3: Optional[Mapping[str, str]] = None,
+) -> PipelineResult:
+    if not WORKER_ARN:
+        raise RuntimeError("WORKER_ARN must be configured for lambda mode")
+
+    if body_bytes is None and body_s3 is None:
+        raise ValueError("Worker invocation requires body_bytes or body_s3")
+
+    event = _build_worker_event(
+        job_id,
+        source,
+        artifact_prefix,
+        body_bytes=body_bytes,
+        body_s3=body_s3,
+    )
+    print(f"[ProcessorFn] Invoking LangGraph worker Lambda for job {job_id}")
+    response = lambda_client.invoke(
+        FunctionName=WORKER_ARN,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(event).encode("utf-8"),
+    )
+
+    payload_stream = response.get("Payload")
+    if payload_stream is None:
+        raise RuntimeError("Worker Lambda response missing payload stream")
+
+    try:
+        raw = payload_stream.read()
+    finally:
+        closer = getattr(payload_stream, "close", None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:
+                pass
+
+    if "FunctionError" in response:
+        message = raw.decode("utf-8", errors="ignore") if raw else "(no error payload)"
+        raise RuntimeError(f"Worker Lambda execution failed: {message}")
+
+    if not raw:
+        raise RuntimeError("Worker Lambda returned empty payload")
+
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Worker Lambda returned invalid JSON") from exc
+
+    return decode_pipeline_result(decoded)
+
+
+def _invoke_worker_http(
+    job_id: str,
+    source: Mapping[str, Any],
+    artifact_prefix: str,
+    *,
+    body_bytes: Optional[bytes] = None,
+    body_s3: Optional[Mapping[str, str]] = None,
+) -> PipelineResult:
+    if not WORKER_URL:
+        raise RuntimeError("WORKER_URL must be configured for http mode")
+
+    if body_bytes is None and body_s3 is None:
+        raise ValueError("Worker invocation requires body_bytes or body_s3")
+
+    event = _build_worker_event(
+        job_id,
+        source,
+        artifact_prefix,
+        body_bytes=body_bytes,
+        body_s3=body_s3,
+    )
+    data = json.dumps(event).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if WORKER_BEARER_TOKEN:
+        headers["Authorization"] = f"Bearer {WORKER_BEARER_TOKEN.strip()}"
+    elif WORKER_AUTH_HEADER:
+        try:
+            name, value = WORKER_AUTH_HEADER.split(":", 1)
+        except ValueError as exc:
+            raise RuntimeError(
+                "WORKER_AUTH_HEADER must be in the format 'Header-Name: value'"
+            ) from exc
+        headers[name.strip()] = value.strip()
+
+    request = urllib_request.Request(
+        WORKER_URL,
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+    print(f"[ProcessorFn] Invoking LangGraph worker HTTP endpoint for job {job_id}")
+    try:
+        with urllib_request.urlopen(request, timeout=900) as response:
+            raw = response.read()
+    except urllib_error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="ignore") if hasattr(exc, "read") else ""
+        raise RuntimeError(f"Worker HTTP error {exc.code}: {detail}") from exc
+    except urllib_error.URLError as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"Worker HTTP invocation failed: {exc}") from exc
+
+    if not raw:
+        raise RuntimeError("Worker HTTP endpoint returned empty payload")
+
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Worker HTTP endpoint returned invalid JSON") from exc
+
+    return decode_pipeline_result(decoded)
+
+
+def _invoke_pipeline(
+    job_id: str,
+    source: Mapping[str, Any],
+    artifact_prefix: str,
+    body: Any,
+    *,
+    body_s3: Optional[Mapping[str, str]] = None,
+    on_phase,
+) -> PipelineResult:
+    mode = WORKER_INVOKE_MODE or "embedded"
+    if mode in {"embedded", "", "local"}:
+        if body is None:
+            raise ValueError("Embedded mode requires a body stream or bytes")
+        return run_pipeline(job_id, source, artifact_prefix, body, on_phase=on_phase)
+
+    body_bytes = _ensure_bytes(body) if body is not None else None
+    if mode == "lambda":
+        return _invoke_worker_lambda(
+            job_id,
+            source,
+            artifact_prefix,
+            body_bytes=body_bytes,
+            body_s3=body_s3,
+        )
+    if mode == "http":
+        return _invoke_worker_http(
+            job_id,
+            source,
+            artifact_prefix,
+            body_bytes=body_bytes,
+            body_s3=body_s3,
+        )
+    raise ValueError(f"Unsupported WORKER_INVOKE_MODE: {mode}")
+
+
+def _log_phase_progress(job_id: str, phases: Mapping[str, Any]) -> None:
+    ordered = [phase for phase in PHASE_ORDER if phase in phases]
+    total = len(ordered) or len(PHASE_ORDER)
+    for index, phase in enumerate(ordered):
+        print(
+            f"[ProcessorFn] Phase {phase} completed for job {job_id} "
+            f"({index + 1}/{total})"
+        )
 
 
 def main(event, _ctx):
@@ -351,7 +333,7 @@ def main(event, _ctx):
     results_key = result_key_for(job_id)
 
     try:
-        if ARTIFACTS_BUCKET and object_exists(ARTIFACTS_BUCKET, results_key):
+        if ARTIFACTS_BUCKET and object_exists(s3, ARTIFACTS_BUCKET, results_key):
             print(
                 f"[ProcessorFn] Results already exist at s3://{ARTIFACTS_BUCKET}/{results_key} (idempotent skip)."
             )
@@ -360,41 +342,70 @@ def main(event, _ctx):
         print(f"[ProcessorFn] Warning: head_object failed for existing results check: {e}")
 
     try:
-        obj = s3.get_object(Bucket=bucket, Key=key)
-        body = obj["Body"]
+        source_descriptor = {"bucket": bucket, "key": key}
+        body_stream: Optional[Any] = None
+        body_s3_descriptor: Optional[Dict[str, str]] = {"bucket": bucket, "key": key}
+        callback = None
+
+        if _is_embedded_mode():
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            body_stream = obj["Body"]
+            callback = _default_callback(job_id)
+            body_s3_descriptor = None
+
         try:
-            result = run_pipeline(
+            result = _invoke_pipeline(
                 job_id,
-                {"bucket": bucket, "key": key},
-                body,
-                artifact_prefix=artifact_prefix,
-                on_phase=_default_callback(job_id),
+                source_descriptor,
+                artifact_prefix,
+                body_stream,
+                body_s3=body_s3_descriptor,
+                on_phase=callback,
             )
         finally:
-            closer = getattr(body, "close", None)
-            if callable(closer):
-                try:
-                    closer()
-                except Exception:
-                    pass
+            if body_stream is not None:
+                closer = getattr(body_stream, "close", None)
+                if callable(closer):
+                    try:
+                        closer()
+                    except Exception:
+                        pass
+
+        if not _is_embedded_mode():
+            _log_phase_progress(job_id, result.phases)
 
         target_bucket = ARTIFACTS_BUCKET or bucket
-        artifact_keys = _persist_pipeline_outputs(job_id, target_bucket, result)
+        artifact_keys = persist_pipeline_outputs(
+            job_id,
+            target_bucket,
+            result,
+            s3_client=s3,
+        )
 
         results_payload = build_results_payload(
             job_id,
             result,
-            source_input=payload_input,
+            source_input=source_descriptor,
             artifact_bucket=target_bucket,
         )
 
         # Best-effort parse debug to aid troubleshooting
         try:
-            _emit_parse_debug(job_id, target_bucket, result.phases.get("profile", {}) or {})
+            emit_parse_debug(
+                job_id,
+                target_bucket,
+                result.phases.get("profile", {}) or {},
+                s3_client=s3,
+            )
         except Exception:
             pass
 
-        _put_object(target_bucket, results_key, _json_bytes(results_payload), "application/json")
+        s3.put_object(
+            Bucket=target_bucket,
+            Key=results_key,
+            Body=json.dumps(results_payload, indent=2, default=str).encode("utf-8"),
+            ContentType="application/json",
+        )
 
         try:
             ddb_upsert_status(
@@ -421,12 +432,12 @@ def main(event, _ctx):
 
         try:
             target_bucket = ARTIFACTS_BUCKET or bucket
-            error_key = results_key.replace("results.json", "error.json")
-            _put_object(
-                target_bucket,
-                error_key,
-                _json_bytes({"jobId": job_id, "error": err_txt}),
-                "application/json",
+            error_key = error_key_for(job_id)
+            s3.put_object(
+                Bucket=target_bucket,
+                Key=error_key,
+                Body=json.dumps({"jobId": job_id, "error": err_txt}, indent=2).encode("utf-8"),
+                ContentType="application/json",
             )
         except Exception as e3:
             print(f"[ProcessorFn] Warning: failed to write error artifact: {e3}")

--- a/services/common/pipeline.py
+++ b/services/common/pipeline.py
@@ -7,6 +7,8 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Mapping, Optional, TYPE_CHECKING
 
+from botocore.exceptions import ClientError
+
 if TYPE_CHECKING:  # pragma: no cover - import only for static typing
     from services.workers.graph.graph import PipelineResult
 else:  # pragma: no cover - at runtime we treat PipelineResult as ``Any``
@@ -26,6 +28,10 @@ def manifest_key_for(job_id: str) -> str:
 
 def phase_key_for(job_id: str, phase: str) -> str:
     return f"artifacts/{job_id}/phases/{phase}.json"
+
+
+def error_key_for(job_id: str) -> str:
+    return f"artifacts/{job_id}/results/error.json"
 
 
 def artifact_key_for(job_id: str, relative: str) -> str:
@@ -164,6 +170,36 @@ def summarize_phase_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return {"fields": keys}
 
 
+def _profile_rows_fallback(profile_phase: Mapping[str, Any], schema: List[Dict[str, Any]]) -> Optional[int]:
+    for key in ("rowCount", "rows", "nRows", "shapeRows"):
+        value = profile_phase.get(key)
+        if isinstance(value, int) and value >= 0:
+            return value
+    shape = profile_phase.get("shape")
+    if isinstance(shape, Mapping) and isinstance(shape.get("rows"), int):
+        return shape["rows"]
+    metrics = profile_phase.get("metrics")
+    if isinstance(metrics, Mapping) and isinstance(metrics.get("rows"), int):
+        return metrics["rows"]
+    return None
+
+
+def _profile_columns_fallback(profile_phase: Mapping[str, Any], schema: List[Dict[str, Any]]) -> Optional[int]:
+    if schema:
+        return len(schema)
+    for key in ("columnCount", "columns", "nCols", "shapeCols"):
+        value = profile_phase.get(key)
+        if isinstance(value, int) and value >= 0:
+            return value
+    shape = profile_phase.get("shape")
+    if isinstance(shape, Mapping) and isinstance(shape.get("columns"), int):
+        return shape["columns"]
+    columns = profile_phase.get("columnProfiles")
+    if isinstance(columns, list):
+        return len(columns)
+    return None
+
+
 def build_results_payload(
     job_id: str,
     result: "PipelineResult",
@@ -173,9 +209,43 @@ def build_results_payload(
     analysis_version: str = ANALYSIS_VERSION,
 ) -> Dict[str, Any]:
     metrics = dict(result.metrics)
+    profile_phase = (
+        result.phases.get("profile")
+        if isinstance(result.phases, Mapping)
+        else None
+    ) or {}
+
+    schema: List[Dict[str, Any]] = []
+    if isinstance(profile_phase, Mapping):
+        columns = profile_phase.get("columnProfiles")
+        if isinstance(columns, list):
+            for column in columns:
+                if not isinstance(column, Mapping):
+                    continue
+                name = column.get("name")
+                if name is None:
+                    continue
+                entry: Dict[str, Any] = {"name": str(name)}
+                inferred = column.get("inferredType")
+                if inferred is not None:
+                    entry["type"] = inferred
+                schema.append(entry)
+
+    rows_value = metrics.get("rows")
+    if not isinstance(rows_value, int):
+        fallback_rows = _profile_rows_fallback(profile_phase, schema)
+        if isinstance(fallback_rows, int):
+            rows_value = fallback_rows
+
+    columns_value = metrics.get("columns")
+    if not isinstance(columns_value, int):
+        fallback_cols = _profile_columns_fallback(profile_phase, schema)
+        if isinstance(fallback_cols, int):
+            columns_value = fallback_cols
+
     summary = {
-        "rows": metrics.get("rows"),
-        "columns": metrics.get("columns"),
+        "rows": rows_value,
+        "columns": columns_value,
         "bytesRead": metrics.get("bytesRead"),
         "datasetCompleteness": metrics.get("datasetCompleteness"),
         "dqScore": metrics.get("dqScore"),
@@ -192,23 +262,6 @@ def build_results_payload(
     if artifact_bucket:
         links["resultsManifest"] = f"s3://{artifact_bucket}/{manifest_key_for(job_id)}"
         links["resultsJson"] = f"s3://{artifact_bucket}/{result_key_for(job_id)}"
-
-    profile_phase = result.phases.get("profile", {})
-    schema: List[Dict[str, Any]] = []
-    if isinstance(profile_phase, Mapping):
-        columns = profile_phase.get("columnProfiles")
-        if isinstance(columns, list):
-            for column in columns:
-                if not isinstance(column, Mapping):
-                    continue
-                name = column.get("name")
-                if name is None:
-                    continue
-                entry: Dict[str, Any] = {"name": str(name)}
-                inferred = column.get("inferredType")
-                if inferred is not None:
-                    entry["type"] = inferred
-                schema.append(entry)
 
     payload = {
         "jobId": job_id,
@@ -229,11 +282,67 @@ def build_results_payload(
     return payload
 
 
+def emit_parse_debug(
+    job_id: str,
+    bucket: str,
+    profile_phase: Mapping[str, Any],
+    *,
+    s3_client,
+) -> Optional[str]:
+    try:
+        debug: Dict[str, Any] = {}
+        shape = profile_phase.get("shape")
+        if isinstance(shape, Mapping):
+            debug["shape"] = {
+                key: int(value)
+                for key, value in shape.items()
+                if isinstance(value, int)
+            }
+        dtypes = profile_phase.get("dtypes")
+        if isinstance(dtypes, Mapping):
+            debug["dtypes"] = {str(key): str(value) for key, value in dtypes.items()}
+        head = profile_phase.get("head")
+        if isinstance(head, list):
+            debug["head"] = head[:3]
+        columns = profile_phase.get("columnProfiles")
+        if isinstance(columns, list):
+            debug["columnNames"] = [
+                str(column.get("name"))
+                for column in columns
+                if isinstance(column, Mapping) and column.get("name")
+            ][:50]
+
+        key = artifact_key_for(job_id, "results/parse_debug.json")
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=_json_bytes(debug),
+            ContentType="application/json",
+        )
+        return key
+    except Exception:
+        return None
+
+
+def object_exists(s3_client, bucket: str, key: str) -> bool:
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code in {"404", "NotFound", "NoSuchKey"}:
+            return False
+        raise
+
+
 __all__ = [
     "ANALYSIS_VERSION",
     "artifact_key_for",
     "build_results_payload",
+    "emit_parse_debug",
+    "error_key_for",
     "manifest_key_for",
+    "object_exists",
     "persist_pipeline_outputs",
     "phase_key_for",
     "result_key_for",

--- a/services/workers/graph/__init__.py
+++ b/services/workers/graph/__init__.py
@@ -1,3 +1,15 @@
-from .app import build_graph, run_pipeline, lambda_handler
+from .app import (
+    build_graph,
+    run_pipeline,
+    lambda_handler,
+    encode_pipeline_result,
+    decode_pipeline_result,
+)
 
-__all__ = ["build_graph", "run_pipeline", "lambda_handler"]
+__all__ = [
+    "build_graph",
+    "run_pipeline",
+    "lambda_handler",
+    "encode_pipeline_result",
+    "decode_pipeline_result",
+]

--- a/services/workers/graph/app.py
+++ b/services/workers/graph/app.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import os
+import time
 import sqlite3
 import base64
 from typing import Any, Dict, Mapping, Optional, Callable
-from collections.abc import Mapping as MappingABC
+from collections.abc import Mapping as MappingABC, Sequence
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 
 from langgraph.graph import END, StateGraph
 try:
@@ -25,7 +29,201 @@ from .core.types import PipelineResult, BinaryInput
 from .core.state import _with_phase  # only if you need it in handlers
 
 
+_ddb_resource = None
+_s3_client = None
+
+_DEFAULT_MAX_BODY_BYTES = 512 * 1024 * 1024  # 512 MB safety guardrail
+_STREAM_CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB chunks keep memory bounded
+
+
+class _LimitedStream:
+    def __init__(self, stream: Any, limit: int) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._consumed = 0
+
+    def read(self, size: int = -1) -> bytes:
+        data = self._stream.read(size)
+        if not data:
+            return data
+        if isinstance(data, memoryview):
+            data = data.tobytes()
+        elif isinstance(data, bytearray):
+            data = bytes(data)
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError("Stream produced non-bytes payload")
+        self._consumed += len(data)
+        if self._consumed > self._limit:
+            raise ValueError(
+                f"Staged input exceeds maximum supported size of {self._limit} bytes"
+            )
+        return data
+
+    def close(self) -> None:
+        closer = getattr(self._stream, "close", None)
+        if callable(closer):
+            closer()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def seek(self, *args: Any, **kwargs: Any) -> Any:
+        seeker = getattr(self._stream, "seek", None)
+        if callable(seeker):
+            return seeker(*args, **kwargs)
+        raise AttributeError("Underlying stream does not support seek")
+
+
+def _resolve_max_body_bytes() -> int:
+    value = os.environ.get("MAX_PIPELINE_BODY_BYTES")
+    if value:
+        try:
+            parsed = int(value)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    return _DEFAULT_MAX_BODY_BYTES
+
+
+_MAX_BODY_BYTES = _resolve_max_body_bytes()
+
+
 PhaseCallback = Optional[Callable[..., None]]
+
+
+def _normalize_for_json(value: Any) -> Any:
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"__b64__": True, "data": base64.b64encode(bytes(value)).decode("ascii")}
+    if isinstance(value, MappingABC):
+        return {str(k): _normalize_for_json(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, Sequence)) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_for_json(v) for v in value]
+    if isinstance(value, set):
+        return [_normalize_for_json(v) for v in sorted(value)]
+    return value
+
+
+def _denormalize_from_json(value: Any) -> Any:
+    if isinstance(value, MappingABC):
+        if value.get("__b64__") and "data" in value:
+            try:
+                return base64.b64decode(value["data"])
+            except Exception:
+                return b""
+        return {k: _denormalize_from_json(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_denormalize_from_json(v) for v in value]
+    return value
+
+
+def encode_pipeline_result(result: PipelineResult) -> Dict[str, Any]:
+    return {
+        "phases": _normalize_for_json(result.phases),
+        "metrics": _normalize_for_json(result.metrics),
+        "manifest": _normalize_for_json(result.manifest),
+        "artifactContents": _normalize_for_json(result.artifact_contents),
+        "correlations": _normalize_for_json(result.correlations),
+        "outliers": _normalize_for_json(result.outliers),
+        "mlInference": _normalize_for_json(result.ml_inference),
+    }
+
+
+def decode_pipeline_result(payload: Mapping[str, Any]) -> PipelineResult:
+    return PipelineResult(
+        phases=_denormalize_from_json(payload.get("phases", {})) or {},
+        metrics=_denormalize_from_json(payload.get("metrics", {})) or {},
+        manifest=_denormalize_from_json(payload.get("manifest", {})) or {},
+        artifact_contents=_denormalize_from_json(payload.get("artifactContents", {})) or {},
+        correlations=_denormalize_from_json(payload.get("correlations", [])) or [],
+        outliers=_denormalize_from_json(payload.get("outliers", [])) or [],
+        ml_inference=_denormalize_from_json(payload.get("mlInference", {})) or {},
+    )
+
+
+def _get_ddb_resource():
+    global _ddb_resource
+    if _ddb_resource is None:
+        _ddb_resource = boto3.resource("dynamodb")
+    return _ddb_resource
+
+
+def _get_s3_client():
+    global _s3_client
+    if _s3_client is None:
+        _s3_client = boto3.client("s3")
+    return _s3_client
+
+
+def _ddb_upsert_status(table_name: str, job_id: str, status: str, **attrs: Any) -> None:
+    table = _get_ddb_resource().Table(table_name)
+    expr_names = {"#s": "status"}
+    expr_vals = {":s": status, ":u": int(time.time())}
+    update_parts = ["#s = :s", "updatedAt = :u"]
+
+    for key, value in attrs.items():
+        placeholder = f":{key}"
+        expr_vals[placeholder] = value
+        update_parts.append(f"{key} = {placeholder}")
+
+    try:
+        table.update_item(
+            Key={"pk": f"job#{job_id}", "sk": "meta"},
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ExpressionAttributeNames=expr_names,
+            ExpressionAttributeValues=expr_vals,
+        )
+    except (BotoCoreError, ClientError) as exc:
+        print(f"[LangGraphWorker] Warning: failed to upsert status for {job_id}: {exc}")
+
+
+def _callback_from_event(event: Mapping[str, Any]) -> PhaseCallback:
+    callback_cfg = event.get("callback")
+    if not isinstance(callback_cfg, MappingABC):
+        return None
+
+    mode = str(callback_cfg.get("mode", "log")).lower()
+    job_id = str(callback_cfg.get("jobId") or event.get("jobId") or "").strip()
+    table_name = str(
+        callback_cfg.get("table")
+        or os.environ.get("TABLE_NAME")
+        or os.environ.get("JOBS_TABLE")
+        or ""
+    ).strip()
+
+    if mode == "ddb" and job_id and table_name:
+        def _callback(phase: str, payload: Mapping[str, Any], index: int, total: int) -> None:
+            progress = int(((index + 1) / max(total, 1)) * 100)
+            summary: Dict[str, Any] = {}
+            text = payload.get("summary") if isinstance(payload, MappingABC) else None
+            if isinstance(text, str):
+                summary["summary"] = text
+            metrics = payload.get("metrics") if isinstance(payload, MappingABC) else None
+            if isinstance(metrics, MappingABC):
+                summary["metrics"] = dict(metrics)
+            try:
+                _ddb_upsert_status(
+                    table_name,
+                    job_id,
+                    "RUNNING",
+                    currentPhase=phase,
+                    phaseIndex=index,
+                    phaseCount=total,
+                    progress=progress,
+                    phaseSummary=summary,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                print(f"[LangGraphWorker] Warning: callback update failed for {phase}: {exc}")
+
+        return _callback
+
+    if mode == "log":
+        def _log_callback(phase: str, _payload: Mapping[str, Any], index: int, total: int) -> None:
+            print(f"[LangGraphWorker] Phase {index + 1}/{total}: {phase}")
+
+        return _log_callback
+
+    return None
 
 
 def build_graph(checkpointer=None):
@@ -49,18 +247,45 @@ def build_graph(checkpointer=None):
     return g.compile(checkpointer=checkpointer)
 
 
-def _to_bytes(b: Any) -> bytes:
+def _stream_to_bytes(reader: Callable[[int], Any], *, limit: Optional[int]) -> bytes:
+    chunks = bytearray()
+    total = 0
+    chunk_size = _STREAM_CHUNK_SIZE
+    while True:
+        try:
+            piece = reader(chunk_size)
+        except TypeError:
+            piece = reader()
+        if not piece:
+            break
+        if not isinstance(piece, (bytes, bytearray, memoryview)):
+            raise TypeError("Stream produced non-bytes payload")
+        data = bytes(piece)
+        total += len(data)
+        if limit is not None and total > limit:
+            raise ValueError(
+                f"Staged input exceeds maximum supported size of {limit} bytes"
+            )
+        chunks.extend(data)
+    return bytes(chunks)
+
+
+def _to_bytes(b: Any, *, limit: Optional[int] = None) -> bytes:
     """
     Normalize a BinaryInput (bytes, bytearray, memoryview, or file-like) to bytes.
     Prevents non-serializable objects (e.g., BytesIO) from leaking into checkpoint state.
     """
+    effective_limit = _MAX_BODY_BYTES if limit is None else limit
     if isinstance(b, (bytes, bytearray, memoryview)):
-        return bytes(b)
-    # file-like (duck-type .read)
+        data = bytes(b)
+        if len(data) > effective_limit:
+            raise ValueError(
+                f"Staged input exceeds maximum supported size of {effective_limit} bytes"
+            )
+        return data
     read = getattr(b, "read", None)
     if callable(read):
-        data = read()
-        return bytes(data) if not isinstance(data, (bytes, bytearray, memoryview)) else bytes(data)
+        return _stream_to_bytes(read, limit=effective_limit)
     raise TypeError(f"Unsupported BinaryInput type: {type(b).__name__}")
 
 
@@ -79,13 +304,22 @@ def _as_mapping(obj: Any) -> Dict[str, Any]:
 def run_pipeline(
     job_id: str,
     source: Mapping[str, Any],
+    artifact_prefix: str,
     body: BinaryInput,
     *,
-    artifact_prefix: str,
     on_phase: PhaseCallback = None,
 ) -> PipelineResult:
-    # Always normalize to raw bytes BEFORE placing into graph state (checkpoint-safe)
-    body_bytes = _to_bytes(body)
+    body_bytes: Optional[bytes] = None
+    body_stream: Optional[BinaryInput] = None
+
+    if isinstance(body, (bytes, bytearray, memoryview)):
+        body_bytes = _to_bytes(body)
+    else:
+        read = getattr(body, "read", None)
+        if callable(read):
+            body_stream = body
+        else:
+            body_bytes = _to_bytes(body)
 
     initial_state: Dict[str, Any] = {
         "job_id": job_id,
@@ -96,6 +330,8 @@ def run_pipeline(
         "phase_outputs": {},
         "artifact_contents": {},
     }
+    if body_stream is not None:
+        initial_state["body"] = body_stream
     if on_phase:
         initial_state["_callback"] = on_phase
 
@@ -133,7 +369,13 @@ def run_pipeline(
             except Exception:
                 pass
 
-            checkpointer = SqliteSaver(conn)
+            if SqliteSaver is not None:
+                checkpointer = SqliteSaver(conn)
+            else:  # pragma: no cover - fallback when sqlite saver unavailable
+                try:
+                    conn.close()
+                except Exception:
+                    pass
 
     app = build_graph(checkpointer=checkpointer if not disable_ckpt else None)
     config = {
@@ -170,25 +412,55 @@ def lambda_handler(event: Mapping[str, Any], _context: Any) -> Dict[str, Any]:
     artifact_prefix = event.get("artifactPrefix") or f"artifacts/{job_id}"
     source = event.get("source") or {}
     body = event.get("body")
-    if body is None:
-        raise ValueError("body is required")
+    body_s3 = event.get("bodyS3")
+    pipeline_body: Optional[BinaryInput] = None
+    limited_stream: Optional[_LimitedStream] = None
 
-    # Accept base64-encoded string or raw bytes
-    if isinstance(body, str):
-        body_bytes = base64.b64decode(body)
+    if body_s3 and isinstance(body_s3, MappingABC):
+        bucket = body_s3.get("bucket")
+        key = body_s3.get("key")
+        if not bucket or not key:
+            raise ValueError("bodyS3 requires bucket and key")
+        client = _get_s3_client()
+        response = client.get_object(Bucket=bucket, Key=key)
+        stream = response.get("Body")
+        if stream is None:
+            raise ValueError("S3 object body missing")
+        content_length = response.get("ContentLength")
+        if isinstance(content_length, int) and content_length > _MAX_BODY_BYTES:
+            raise ValueError(
+                f"Staged input is {content_length} bytes which exceeds the limit of {_MAX_BODY_BYTES}"
+            )
+        limited_stream = _LimitedStream(stream, _MAX_BODY_BYTES)
+        pipeline_body = limited_stream
+    elif body is None:
+        raise ValueError("body or bodyS3 is required")
+    elif isinstance(body, str):
+        pipeline_body = base64.b64decode(body)
     elif isinstance(body, (bytes, bytearray, memoryview)):
-        body_bytes = bytes(body)
+        pipeline_body = bytes(body)
     else:
-        # If an API caller sent a file-like object, normalize it too
-        body_bytes = _to_bytes(body)
+        pipeline_body = _to_bytes(body)
 
-    result = run_pipeline(job_id, source, body_bytes, artifact_prefix=artifact_prefix)
-    return {
-        "jobId": job_id,
-        "phases": result.phases,
-        "metrics": result.metrics,
-        "manifest": result.manifest,
-        "correlations": result.correlations,
-        "outliers": result.outliers,
-        "mlInference": result.ml_inference,
-    }
+    if pipeline_body is None:
+        pipeline_body = b""
+
+    callback = _callback_from_event(event)
+
+    try:
+        result = run_pipeline(
+            job_id,
+            source,
+            artifact_prefix,
+            pipeline_body,
+            on_phase=callback,
+        )
+    finally:
+        if limited_stream is not None:
+            try:
+                limited_stream.close()
+            except Exception:
+                pass
+
+    encoded = encode_pipeline_result(result)
+    return {"jobId": job_id, **encoded}

--- a/services/workers/graph/graph.py
+++ b/services/workers/graph/graph.py
@@ -1,1 +1,22 @@
-from .app import run_pipeline, build_graph, lambda_handler
+from .app import (
+    run_pipeline,
+    build_graph,
+    lambda_handler,
+    encode_pipeline_result,
+    decode_pipeline_result,
+)
+from .core.constants import PHASE_ORDER, _ARCHIVE_STREAM_CHUNK_SIZE
+from .core.types import PipelineResult
+from .io.ingest import ingest_dataset
+
+__all__ = [
+    "run_pipeline",
+    "build_graph",
+    "lambda_handler",
+    "encode_pipeline_result",
+    "decode_pipeline_result",
+    "PHASE_ORDER",
+    "_ARCHIVE_STREAM_CHUNK_SIZE",
+    "PipelineResult",
+    "ingest_dataset",
+]

--- a/services/workers/graph/nodes/ingest.py
+++ b/services/workers/graph/nodes/ingest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
-from typing import Any, Dict, MutableMapping, Optional, Union, IO
+from typing import Any, Dict, MutableMapping, Optional
+
 from ..core.state import _with_phase, _emit_callback
 from ..io.ingest import ingest_dataset
+from ..core.types import BinaryInput
 
 def ingest_node(state: MutableMapping[str, Any]) -> Dict[str, Any]:
     source = state.get("source", {}) or {}
@@ -11,18 +13,21 @@ def ingest_node(state: MutableMapping[str, Any]) -> Dict[str, Any]:
     if body_input is None:
         body_input = state.get("body")
 
+    dataset_input: BinaryInput
     if body_input is None:
-        data_bytes = b""
-    elif isinstance(body_input, (bytes, bytearray)):
-        data_bytes = bytes(body_input)
+        dataset_input = b""
     else:
-        try:
-            body_input.seek(0)
-        except Exception:
-            pass
-        data_bytes = body_input.read()
+        if isinstance(body_input, bytearray):
+            dataset_input = bytes(body_input)
+        else:
+            if hasattr(body_input, "seek"):
+                try:
+                    body_input.seek(0)
+                except Exception:
+                    pass
+            dataset_input = body_input
 
-    dataset = ingest_dataset(key, data_bytes)
+    dataset = ingest_dataset(key, dataset_input)
 
     closer = getattr(body_input, "close", None)
     if callable(closer):

--- a/tests/integration/test_api_workflow.py
+++ b/tests/integration/test_api_workflow.py
@@ -213,7 +213,7 @@ def api_app(monkeypatch):
     graph_module = importlib.import_module("services.workers.graph.graph")
     stub_phase_order = ["ingest", "profile", "descriptive_stats", "nl_report", "finalize"]
 
-    def _stub_run_pipeline(job_id, source, body, *, artifact_prefix, on_phase=None):
+    def _stub_run_pipeline(job_id, source, artifact_prefix, body, *, on_phase=None):
         phases = {
             "ingest": {"summary": "ingested", "rows": 2, "sourceFormat": "csv"},
             "profile": {"columnProfiles": [{"name": "value", "inferredType": "integer"}]},

--- a/tests/integration/test_graph_pipeline.py
+++ b/tests/integration/test_graph_pipeline.py
@@ -95,7 +95,11 @@ class _ChunkedBinaryStream:
         return True
 
 
-ensure_langgraph_stub()
+def _ensure_state_graph_stub() -> None:
+    ensure_langgraph_stub()
+
+
+_ensure_state_graph_stub()
 module = importlib.import_module("services.workers.graph.graph")
 importlib.reload(module)
 run_pipeline = module.run_pipeline
@@ -113,7 +117,7 @@ PHASE_ORDER = module.PHASE_ORDER
 )
 def test_pipeline_ingests_diverse_formats(key, body, expected_format):
     job_id = f"job-{expected_format}"
-    result = run_pipeline(job_id, {"key": key}, body, artifact_prefix=f"artifacts/{job_id}")
+    result = run_pipeline(job_id, {"key": key}, f"artifacts/{job_id}", body)
 
     for phase in PHASE_ORDER:
         assert phase in result.phases
@@ -134,6 +138,18 @@ def test_pipeline_ingests_diverse_formats(key, body, expected_format):
     assert f"artifacts/{job_id}/results/bundles/analytics_bundle.zip" in manifest_keys
     assert f"artifacts/{job_id}/phases/phase_payloads.zip" in manifest_keys
     assert f"artifacts/{job_id}/results/report.html" in manifest_keys
+
+
+def test_pipeline_accepts_streaming_body():
+    job_id = "job-streaming"
+    stream = _ChunkedBinaryStream(_csv_bytes(SAMPLE_ROWS), chunk_size=1024)
+    result = run_pipeline(job_id, {"key": "sample.csv"}, f"artifacts/{job_id}", stream)
+
+    ingest = result.phases["ingest"]
+    assert ingest["rows"] == len(SAMPLE_ROWS)
+    assert ingest["sourceFormat"] == "csv"
+    manifest_keys = {entry["key"] for entry in result.manifest.get("artifacts", [])}
+    assert f"artifacts/{job_id}/results/results.json" in manifest_keys
     assert any(key.startswith(f"artifacts/{job_id}/results/graphs/") for key in manifest_keys)
 
     contents_keys = result.artifact_contents.keys()
@@ -172,7 +188,12 @@ def test_pipeline_streams_delimited_input_without_full_decode():
     stream = _ChunkedBinaryStream(payload, chunk_size=7)
     job_id = "job-streaming"
 
-    result = run_pipeline(job_id, {"key": "stream.csv"}, stream, artifact_prefix=f"artifacts/{job_id}")
+    result = run_pipeline(
+        job_id,
+        {"key": "stream.csv"},
+        f"artifacts/{job_id}",
+        stream,
+    )
 
     ingest = result.phases["ingest"]
     assert ingest["rows"] == len(SAMPLE_ROWS)
@@ -189,7 +210,12 @@ def test_pipeline_handles_duplicate_column_headers():
     ).encode("utf-8")
 
     job_id = "job-duplicate-headers"
-    result = run_pipeline(job_id, {"key": "duplicate.csv"}, csv_payload, artifact_prefix=f"artifacts/{job_id}")
+    result = run_pipeline(
+        job_id,
+        {"key": "duplicate.csv"},
+        f"artifacts/{job_id}",
+        csv_payload,
+    )
 
     ingest = result.phases["ingest"]
     assert ingest["rows"] == 2

--- a/tests/integration/utils/langgraph.py
+++ b/tests/integration/utils/langgraph.py
@@ -29,7 +29,7 @@ def ensure_langgraph_stub() -> None:
             self._nodes = nodes
             self._order = order
 
-        def invoke(self, initial_state):
+        def invoke(self, initial_state, config=None):  # pragma: no cover - config ignored in stub
             state = dict(initial_state)
             for name in self._order:
                 update = self._nodes[name](state)
@@ -52,7 +52,7 @@ def ensure_langgraph_stub() -> None:
         def add_edge(self, source, dest):
             self._edges.setdefault(source, []).append(dest)
 
-        def compile(self):
+        def compile(self, checkpointer=None):  # pragma: no cover - checkpointer ignored in stub
             order: List[str] = []
             current = self._entry
             visited: set[str] = set()

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -80,10 +80,10 @@ def test_pipeline_no_checkpoint(env_guard, tmp_path):
     os.environ["MF_DISABLE_CHECKPOINT"] = "1"
 
     res = run_pipeline(
-        job_id="pytest-smoke-no-ckpt",
-        source={"key": "iris.csv"},
-        body=io.BytesIO(CSV_SMALL),
-        artifact_prefix=f"artifacts/pytest-no-ckpt",
+        "pytest-smoke-no-ckpt",
+        {"key": "iris.csv"},
+        f"artifacts/pytest-no-ckpt",
+        io.BytesIO(CSV_SMALL),
     )
 
     _assert_pipeline_result(res)
@@ -101,10 +101,10 @@ def test_pipeline_with_checkpoint(env_guard, tmp_path):
     os.environ["CHECKPOINT_SQLITE_PATH"] = str(ckpt_path)
 
     res = run_pipeline(
-        job_id="pytest-smoke-ckpt",
-        source={"key": "iris.csv"},
-        body=io.BytesIO(CSV_SMALL),
-        artifact_prefix=f"artifacts/pytest-ckpt",
+        "pytest-smoke-ckpt",
+        {"key": "iris.csv"},
+        f"artifacts/pytest-ckpt",
+        io.BytesIO(CSV_SMALL),
     )
 
     _assert_pipeline_result(res)

--- a/tests/test_processor_worker_invocation.py
+++ b/tests/test_processor_worker_invocation.py
@@ -1,0 +1,198 @@
+import importlib
+import io
+import json
+from typing import Optional
+
+import pytest
+
+from tests.integration.utils.langgraph import ensure_langgraph_stub
+
+ensure_langgraph_stub()
+
+from services.workers.graph.graph import PipelineResult, encode_pipeline_result
+
+
+@pytest.mark.parametrize("mode", ["lambda", "http"])
+def test_remote_worker_uses_s3_pointer(monkeypatch, mode):
+    monkeypatch.setenv("JOBS_TABLE", "jobs-table")
+    monkeypatch.setenv("ARTIFACTS_BUCKET", "artifacts")
+    monkeypatch.setenv("WORKER_INVOKE_MODE", mode)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    if mode == "lambda":
+        monkeypatch.setenv("WORKER_ARN", "arn:aws:lambda:us-east-1:123:function:worker")
+        monkeypatch.delenv("WORKER_URL", raising=False)
+    else:
+        monkeypatch.setenv("WORKER_URL", "https://worker.example.com")
+        monkeypatch.delenv("WORKER_ARN", raising=False)
+
+    module = importlib.import_module("lambdas.processor.handler")
+    module = importlib.reload(module)
+
+    # ensure we don't make real network calls
+    monkeypatch.setattr(module, "s3", object())
+
+    result = PipelineResult(
+        phases={"ingest": {"summary": "ok"}},
+        metrics={},
+        manifest={},
+        artifact_contents={},
+        correlations=[],
+        outliers=[],
+        ml_inference={},
+    )
+
+    body_pointer = {"bucket": "artifacts", "key": "artifacts/job-123/input/data.csv"}
+
+    if mode == "lambda":
+        class StubLambdaClient:
+            def __init__(self):
+                self.payloads = []
+
+            def invoke(self, FunctionName, InvocationType, Payload):
+                event = json.loads(Payload.decode("utf-8"))
+                self.payloads.append(event)
+                payload_bytes = json.dumps(encode_pipeline_result(result)).encode("utf-8")
+                return {"StatusCode": 200, "Payload": io.BytesIO(payload_bytes)}
+
+        stub = StubLambdaClient()
+        monkeypatch.setattr(module, "lambda_client", stub)
+        returned = module._invoke_worker_lambda(
+            "job-123",
+            body_pointer,
+            "artifacts/job-123",
+            body_s3=body_pointer,
+        )
+        assert returned == result
+        assert stub.payloads and stub.payloads[0]["bodyS3"] == body_pointer
+        assert "body" not in stub.payloads[0]
+    else:
+        class StubHTTPResponse(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+
+        def fake_urlopen(request, timeout):
+            event = json.loads(request.data.decode("utf-8"))
+            fake_urlopen.last_payload = event
+            fake_urlopen.last_headers = dict(request.headers)
+            payload_bytes = json.dumps(encode_pipeline_result(result)).encode("utf-8")
+            return StubHTTPResponse(payload_bytes)
+
+        fake_urlopen.last_payload = None
+        fake_urlopen.last_headers = {}
+        monkeypatch.setattr(module.urllib_request, "urlopen", fake_urlopen)
+        returned = module._invoke_worker_http(
+            "job-123",
+            body_pointer,
+            "artifacts/job-123",
+            body_s3=body_pointer,
+        )
+        assert returned == result
+        assert fake_urlopen.last_payload is not None
+        assert fake_urlopen.last_payload["bodyS3"] == body_pointer
+        assert "body" not in fake_urlopen.last_payload
+        header_map = {k.lower(): v for k, v in fake_urlopen.last_headers.items()}
+        assert header_map.get("content-type") == "application/json"
+
+
+def _stub_http_worker(monkeypatch, bearer: Optional[str] = None, header: Optional[str] = None):
+    monkeypatch.setenv("JOBS_TABLE", "jobs-table")
+    monkeypatch.setenv("ARTIFACTS_BUCKET", "artifacts")
+    monkeypatch.setenv("WORKER_INVOKE_MODE", "http")
+    monkeypatch.setenv("WORKER_URL", "https://worker.example.com")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    if bearer is not None:
+        monkeypatch.setenv("WORKER_BEARER_TOKEN", bearer)
+    else:
+        monkeypatch.delenv("WORKER_BEARER_TOKEN", raising=False)
+    if header is not None:
+        monkeypatch.setenv("WORKER_AUTH_HEADER", header)
+    else:
+        monkeypatch.delenv("WORKER_AUTH_HEADER", raising=False)
+
+    module = importlib.import_module("lambdas.processor.handler")
+    return importlib.reload(module)
+
+
+def test_http_worker_uses_bearer_token(monkeypatch):
+    module = _stub_http_worker(monkeypatch, bearer="super-secret")
+
+    class StubHTTPResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    result = PipelineResult(
+        phases={},
+        metrics={},
+        manifest={},
+        artifact_contents={},
+        correlations=[],
+        outliers=[],
+        ml_inference={},
+    )
+
+    def fake_urlopen(request, timeout):
+        fake_urlopen.last_headers = dict(request.headers)
+        payload_bytes = json.dumps(encode_pipeline_result(result)).encode("utf-8")
+        return StubHTTPResponse(payload_bytes)
+
+    fake_urlopen.last_headers = {}
+    monkeypatch.setattr(module.urllib_request, "urlopen", fake_urlopen)
+
+    module._invoke_worker_http(
+        "job-123",
+        {"bucket": "artifacts", "key": "artifacts/job-123/input/data.csv"},
+        "artifacts/job-123",
+        body_s3={"bucket": "artifacts", "key": "input"},
+    )
+
+    header_map = {k.lower(): v for k, v in fake_urlopen.last_headers.items()}
+    assert header_map.get("authorization") == "Bearer super-secret"
+
+
+def test_http_worker_uses_custom_header(monkeypatch):
+    module = _stub_http_worker(monkeypatch, header="X-Api-Key: abc123")
+
+    class StubHTTPResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    result = PipelineResult(
+        phases={},
+        metrics={},
+        manifest={},
+        artifact_contents={},
+        correlations=[],
+        outliers=[],
+        ml_inference={},
+    )
+
+    def fake_urlopen(request, timeout):
+        fake_urlopen.last_headers = dict(request.headers)
+        payload_bytes = json.dumps(encode_pipeline_result(result)).encode("utf-8")
+        return StubHTTPResponse(payload_bytes)
+
+    fake_urlopen.last_headers = {}
+    monkeypatch.setattr(module.urllib_request, "urlopen", fake_urlopen)
+
+    module._invoke_worker_http(
+        "job-456",
+        {"bucket": "artifacts", "key": "artifacts/job-456/input/data.csv"},
+        "artifacts/job-456",
+        body_s3={"bucket": "artifacts", "key": "input"},
+    )
+
+    header_map = {k.lower(): v for k, v in fake_urlopen.last_headers.items()}
+    assert header_map.get("x-api-key") == "abc123"
+    assert "authorization" not in header_map


### PR DESCRIPTION
## Summary
- stream staged S3 bodies through the LangGraph worker with bounded wrappers while teaching the ingest node to consume file-like inputs without loading everything into memory
- add optional HTTP authentication for remote worker invocations, document the MAX_PIPELINE_BODY_BYTES guardrail, and allocate larger ephemeral storage for the processor image
- cover the new streaming and auth paths with targeted pipeline and processor unit tests

## Testing
- pytest tests/test_processor_worker_invocation.py
- pytest tests/integration/test_graph_pipeline.py::test_pipeline_accepts_streaming_body


------
https://chatgpt.com/codex/tasks/task_e_68ea9c9ee5848322b002c9a4becbc32f